### PR TITLE
[jemalloc_integration] original commit:

### DIFF
--- a/jemalloc/src/ctl.c
+++ b/jemalloc/src/ctl.c
@@ -627,6 +627,8 @@ ctl_growk(unsigned partition)
 		if (ctl_stats.narenas != narenas_auto)
 			idalloc(arenas_old);
 	}
+	if (ctl_stats.narenas != narenas_auto)
+		idalloc(ctl_stats.arenas);
 	ctl_stats.arenas = astats;
 	ctl_stats.narenas++;
 


### PR DESCRIPTION
Author: Krzysztof Czurylo <krzysztof.czurylo@intel.com>
Date:   Fri Oct 9 22:06:41 2015 +0200

    fix memory leak in ctl_growk()

    Fixes the exponential memory usage growth when creating a large number
    of extended arenas in libmemkind.

    Already fixed in jemalloc 4.0, so there's no need to merge it upstream.