### PR TITLE
Fix zeroing pages for file-backed kinds/partitions

### DIFF
--- a/jemalloc/src/chunk_mmap.c
+++ b/jemalloc/src/chunk_mmap.c
@@ -42,6 +42,7 @@ pages_map(void *addr, size_t size
 	    PAGE_READWRITE);
 #else
 #ifdef JEMALLOC_ENABLE_MEMKIND
+	partition &= ~JEMALLOC_MEMKIND_FILE_MAPPED;
 	if (partition && memkind_partition_mmap) {
 		ret = memkind_partition_mmap(partition, addr, size);
 	}

--- a/jemalloc/src/huge.c
+++ b/jemalloc/src/huge.c
@@ -266,15 +266,26 @@ huge_dalloc(void *ptr, bool unmap)
 
 	/* Extract from tree of huge allocations. */
 	key.addr = ptr;
+
 #ifdef JEMALLOC_ENABLE_MEMKIND
 	key.partition = -1;
 	do {
 		key.partition++;
-#endif
 		node = extent_tree_ad_search(&huge, &key);
-#ifdef JEMALLOC_ENABLE_MEMKIND
 	} while ((node == NULL || node->partition != key.partition) &&
 		 key.partition < 256); /* FIXME hard coding partition max to 256 */
+
+	if (node == NULL) {
+		/* if not found, try with file-mapped partitions */
+		key.partition = JEMALLOC_MEMKIND_FILE_MAPPED - 1;
+		do {
+			key.partition++;
+			node = extent_tree_ad_search(&huge, &key);
+		} while ((node == NULL || node->partition != key.partition) &&
+			 key.partition < JEMALLOC_MEMKIND_FILE_MAPPED + 256); /* FIXME hard coding partition max to 256 */
+	}
+#else
+	node = extent_tree_ad_search(&huge, &key);
 #endif
 
 	assert(node != NULL);
@@ -316,15 +327,28 @@ huge_salloc(const void *ptr
 
 	/* Extract from tree of huge allocations. */
 	key.addr = __DECONST(void *, ptr);
+
 #ifdef JEMALLOC_ENABLE_MEMKIND
-	key.partition = partition - 1;
-	do {
-		key.partition++;
-#endif
-		node = extent_tree_ad_search(&huge, &key);
-#ifdef JEMALLOC_ENABLE_MEMKIND
-	} while((node == NULL || node->partition != key.partition) &&
-		key.partition < 256); /* FIXME hard coding partition max to 256 */
+	if (partition & JEMALLOC_MEMKIND_FILE_MAPPED == 0) {
+		key.partition = partition - 1;
+		do {
+			key.partition++;
+			node = extent_tree_ad_search(&huge, &key);
+		} while ((node == NULL || node->partition != key.partition) &&
+			 key.partition < 256); /* FIXME hard coding partition max to 256 */
+	}
+
+	if (node == NULL) {
+		/* if not found, try with file-mapped partitions */
+		key.partition = (partition | JEMALLOC_MEMKIND_FILE_MAPPED) - 1;
+		do {
+			key.partition++;
+			node = extent_tree_ad_search(&huge, &key);
+		} while ((node == NULL || node->partition != key.partition) &&
+			 key.partition < JEMALLOC_MEMKIND_FILE_MAPPED + 256); /* FIXME hard coding partition max to 256 */
+	}
+#else
+	node = extent_tree_ad_search(&huge, &key);
 #endif
 
 	assert(node != NULL);

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -61,6 +61,9 @@ int memkind_pmem_create(struct memkind *kind, const struct memkind_ops *ops,
         goto exit;
     }
 
+    /* mark this kind/partition as file-mapped */
+    kind->partition |= JEMALLOC_MEMKIND_FILE_MAPPED;
+
     err = memkind_arena_create(kind, ops, name);
     if (err) {
         goto exit;

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -113,6 +113,32 @@ TEST_F(MemkindPmemTests, PmemCalloc)
     memkind_free(pmem_kind, default_str);
 }
 
+TEST_F(MemkindPmemTests, PmemCallocHuge)
+{
+    const size_t size = CHUNK_SIZE;
+    const size_t num = 1;
+    char *default_str = NULL;
+
+    default_str = (char *)memkind_calloc(pmem_kind, num, size);
+    EXPECT_TRUE(NULL != default_str);
+    EXPECT_EQ(*default_str, 0);
+
+    sprintf(default_str, "memkind_calloc MEMKIND_PMEM\n");
+    printf("%s", default_str);
+
+    memkind_free(pmem_kind, default_str);
+
+    // allocate the buffer of the same size (likely at the same address)
+    default_str = (char *)memkind_calloc(pmem_kind, num, size);
+    EXPECT_TRUE(NULL != default_str);
+    EXPECT_EQ(*default_str, 0);
+
+    sprintf(default_str, "memkind_calloc MEMKIND_PMEM\n");
+    printf("%s", default_str);
+
+    memkind_free(pmem_kind, default_str);
+}
+
 TEST_F(MemkindPmemTests, PmemGetSize)
 {
     const size_t size = 512;


### PR DESCRIPTION
Page purging mechanism cannot be used for file-backed partitions.
Recycled chunks from such partitions must be assumed non-zeroed and
cleared explicitly by jemalloc.
File-backed kinds/partitions (i.e. PMEM kinds) are identified by
setting the most significant bit in the partition number.