### PR TITLE
removed `-Werror`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -382,7 +382,7 @@ noinst_LTLIBRARIES =
 noinst_HEADERS =
 TESTS =
 
-req_flags = -fvisibility=hidden -Wall -Werror -msse4.2 -D_GNU_SOURCE -DMEMKIND_INTERNAL_API -DJE_PREFIX=$(JE_PREFIX)
+req_flags = -fvisibility=hidden -Wall -msse4.2 -D_GNU_SOURCE -DMEMKIND_INTERNAL_API -DJE_PREFIX=$(JE_PREFIX)
 
 AM_CFLAGS = $(req_flags)
 AM_CXXFLAGS = $(req_flags)

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AC_INIT([memkind],m4_esyscmd([tr -d '\n' < VERSION]))
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([memkind.spec.mk])
 
-AM_INIT_AUTOMAKE([-Wall -Werror foreign 1.11 silent-rules subdir-objects parallel-tests tar-pax])
+AM_INIT_AUTOMAKE([-Wall foreign 1.11 silent-rules subdir-objects parallel-tests tar-pax])
 AM_SILENT_RULES([yes])
 
 # Checks for programs and libraries.
@@ -48,7 +48,7 @@ AM_PROG_CC_C_O
 #============================tls===============================================
 # Check for tls_model attribute support
 SAVED_CFLAGS="${CFLAGS}"
-CFLAGS="$CFLAGS -Werror"
+CFLAGS="$CFLAGS"
 AC_MSG_CHECKING([for tls_model attribute support])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 [[


### PR DESCRIPTION
I really like to compile with `-Werror` as well, but it can break the build when using a different compiler like e.g. the Intel(r) C Compiler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/51)
<!-- Reviewable:end -->
