### PR TITLE
memkind_destroy_kind fix

### DIFF
--- a/include/memkind/internal/memkind_private.h
+++ b/include/memkind/internal/memkind_private.h
@@ -69,6 +69,7 @@ extern "C" {
 #define jemk_memalign               JE_SYMBOL(memalign)
 #define jemk_posix_memalign         JE_SYMBOL(posix_memalign)
 #define jemk_free                   JE_SYMBOL(free)
+#define jemk_dallocx                JE_SYMBOL(dallocx)
 #define jemk_malloc_usable_size     JE_SYMBOL(malloc_usable_size)
 
 enum memkind_const_private {

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (C) 2014 - 2017 Intel Corporation.
+.\" Copyright (C) 2014 - 2018 Intel Corporation.
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@ Note: This is EXEPRIMENTAL API. The functionality and the header file itself can
 .BI "void *memkind_arena_realloc(struct memkind " "*kind" ", void " "*ptr" ", size_t " "size" );
 .BI "int memkind_thread_get_arena(struct memkind " "*kind" ", unsigned int " "*arena", size_t " "size" );
 .BI "int memkind_bijective_get_arena(struct memkind " "*kind" ", unsigned int " "*arena", size_t " "size" );
+.BI "void memkind_arena_free(struct memkind " "*kind" ", void " "*ptr" );
 .br
 .SH DESCRIPTION
 This header file is a collection of functions can be used to populate
@@ -142,8 +143,20 @@ index to be used with the MALLOCX_ARENA macro to set flags for jemalloc's
 .BR mallocx ().
 Use of this operation implies that only one arena is used for the
 .IR kind .
+.PP
+.BR memkind_arena_free ()
+is an implementation of the memkind "free" operation for memory
+kinds that use jemalloc.  It causes the allocated memory referenced by
+.IR ptr ,
+which must have been returned by a previous call to
+.BR memkind_arena_malloc () ,
+.BR memkind_arena_calloc ()
+or
+.BR memkind_arena_realloc ()
+to be made available for future allocations.
+It uses the memkind "get_arena" operation to select the arena.
 .SH "COPYRIGHT"
-Copyright (C) 2014 - 2016 Intel Corporation. All rights reserved.
+Copyright (C) 2014 - 2018 Intel Corporation. All rights reserved.
 .SH "SEE ALSO"
 .BR memkind (3),
 .BR memkind_default (3),

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -25,6 +25,7 @@
 #include <memkind/internal/heap_manager.h>
 #include <memkind/internal/tbb_wrapper.h>
 #include <memkind/internal/memkind_arena.h>
+#include <memkind/internal/memkind_default.h>
 
 #include <stdio.h>
 #include <pthread.h>
@@ -41,7 +42,7 @@ struct heap_manager_ops {
 
 struct heap_manager_ops arena_heap_manager_g = {
     .init = memkind_arena_init,
-    .heap_manager_free = memkind_arena_free
+    .heap_manager_free = memkind_default_free
 };
 
 struct heap_manager_ops tbb_heap_manager_g = {

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -313,10 +313,32 @@ MEMKIND_EXPORT int memkind_create_kind(memkind_memtype_t memtype_flags,
     return MEMKIND_ERROR_INVALID;
 }
 
+static void memkind_destroy_kind_from_register(unsigned int i, memkind_t kind)
+{
+    memkind_registry_g.partition_map[i] = NULL;
+    --memkind_registry_g.num_kind;
+    if (i >= MEMKIND_NUM_BASE_KIND) {
+        jemk_free(kind);
+    }
+}
+
 /* Kind destruction. */
 MEMKIND_EXPORT int memkind_destroy_kind(memkind_t kind)
 {
-    return kind->ops->destroy(kind);
+    if (pthread_mutex_lock(&memkind_registry_g.lock) != 0)
+        assert(0 && "failed to acquire mutex");
+    unsigned int i;
+    int err = kind->ops->destroy(kind);
+    for (i = 0; i < MEMKIND_MAX_KIND; ++i) {
+        if (memkind_registry_g.partition_map[i] &&
+            strcmp(kind->name, memkind_registry_g.partition_map[i]->name) == 0) {
+            memkind_destroy_kind_from_register(i,kind);
+            break;
+        }
+    }
+    if (pthread_mutex_unlock(&memkind_registry_g.lock) != 0)
+        assert(0 && "failed to release mutex");
+    return err;
 }
 
 /* Declare weak symbols for allocator decorators */
@@ -418,7 +440,8 @@ static int memkind_create(struct memkind_ops *ops, const char *name,
                           struct memkind **kind)
 {
     int err;
-    int i;
+    unsigned int i;
+    unsigned int id_kind = 0;
 
     *kind = NULL;
     if (pthread_mutex_lock(&memkind_registry_g.lock) != 0)
@@ -441,8 +464,12 @@ static int memkind_create(struct memkind_ops *ops, const char *name,
         err = MEMKIND_ERROR_BADOPS;
         goto exit;
     }
-    for (i = 0; i < memkind_registry_g.num_kind; ++i) {
-        if (strcmp(name, memkind_registry_g.partition_map[i]->name) == 0) {
+    for (i = 0; i < MEMKIND_MAX_KIND; ++i) {
+        if (memkind_registry_g.partition_map[i] == NULL) {
+            id_kind = i;
+            break;
+        } else if (strcmp(name, memkind_registry_g.partition_map[i]->name) == 0) {
+            log_err("Kind with the name %s already exists", name);
             err = MEMKIND_ERROR_INVALID;
             goto exit;
         }
@@ -459,7 +486,7 @@ static int memkind_create(struct memkind_ops *ops, const char *name,
     if (err) {
         goto exit;
     }
-    memkind_registry_g.partition_map[memkind_registry_g.num_kind] = *kind;
+    memkind_registry_g.partition_map[id_kind] = *kind;
     ++memkind_registry_g.num_kind;
 
     (*kind)->init_once = PTHREAD_ONCE_INIT;
@@ -478,25 +505,23 @@ __attribute__((destructor))
 static int memkind_finalize(void)
 {
     struct memkind *kind;
-    int i;
+    unsigned int i;
     int err = 0;
 
     if (pthread_mutex_lock(&memkind_registry_g.lock) != 0)
         assert(0 && "failed to acquire mutex");
 
-    for (i = 0; i < memkind_registry_g.num_kind; ++i) {
+    for (i = 0; i < MEMKIND_MAX_KIND; ++i) {
         kind = memkind_registry_g.partition_map[i];
         if (kind && kind->ops->finalize) {
             err = kind->ops->finalize(kind);
             if (err) {
                 goto exit;
             }
-            memkind_registry_g.partition_map[i] = NULL;
-            if (i >= MEMKIND_NUM_BASE_KIND) {
-                jemk_free(kind);
-            }
+            memkind_destroy_kind_from_register(i, kind);
         }
     }
+    assert(memkind_registry_g.num_kind == 0);
 
 exit:
     if (pthread_mutex_unlock(&memkind_registry_g.lock) != 0)

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -495,7 +495,8 @@ MEMKIND_EXPORT void *memkind_arena_realloc(struct memkind *kind, void *ptr,
                 ptr = jemk_mallocx_check(size,
                                          MALLOCX_ARENA(arena) | get_tcache_flag(kind->partition, size));
             } else {
-                ptr = jemk_rallocx_check(ptr, size, MALLOCX_ARENA(arena));
+                ptr = jemk_rallocx_check(ptr, size,
+                                         MALLOCX_ARENA(arena) | get_tcache_flag(kind->partition, size));
             }
         }
     }

--- a/src/memkind_default.c
+++ b/src/memkind_default.c
@@ -48,7 +48,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_DEFAULT_OPS = {
     .realloc = memkind_default_realloc,
     .free = memkind_default_free,
     .init_once = memkind_default_init_once,
-    .malloc_usable_size = memkind_default_malloc_usable_size
+    .malloc_usable_size = memkind_default_malloc_usable_size,
+    .finalize = memkind_default_destroy
 };
 
 MEMKIND_EXPORT int memkind_default_create(struct memkind *kind,

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -41,10 +41,11 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_PMEM_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = memkind_default_free,
+    .free = memkind_arena_free,
     .mmap = memkind_pmem_mmap,
     .get_mmap_flags = memkind_pmem_get_mmap_flags,
     .get_arena = memkind_thread_get_arena,
+    .finalize = memkind_pmem_destroy,
     .malloc_usable_size = memkind_default_malloc_usable_size
 };
 
@@ -95,6 +96,9 @@ bool pmem_extent_dalloc(extent_hooks_t *extent_hooks,
                         bool committed,
                         unsigned arena_ind)
 {
+    if (munmap(addr, size) == -1) {
+        log_err("munmap failed!");
+    }
     /* do nothing - report failure (opt-out) */
     return true;
 }

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -48,7 +48,10 @@ protected:
     }
 
     void TearDown()
-    {}
+    {
+        int err = memkind_destroy_kind(pmem_kind);
+        ASSERT_EQ(0, err);
+    }
 };
 
 static void pmem_get_size(struct memkind *kind, size_t& total, size_t& free)
@@ -203,13 +206,15 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocUsableSize)
         EXPECT_LE(diff, check_sizes[i].spacing);
         memkind_free(pmem_temp, alloc);
     }
+    err = memkind_destroy_kind(pmem_temp);
+    EXPECT_EQ(0, err);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemResize)
 {
     const size_t size = MEMKIND_PMEM_CHUNK_SIZE;
     char *pmem_str10 = nullptr;
-    char *pmem_strX  = nullptr;
+    char *pmem_strX = nullptr;
     memkind_t pmem_kind_no_limit = nullptr;
     memkind_t pmem_kind_not_possible = nullptr;
     int err = 0;
@@ -237,8 +242,140 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemResize)
     memkind_free(pmem_kind_no_limit, pmem_str10);
     memkind_free(pmem_kind_no_limit, pmem_strX);
 
+    err = memkind_destroy_kind(pmem_kind_no_limit);
+    EXPECT_EQ(0, err);
+
     err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE-1,
                               &pmem_kind_not_possible);
     EXPECT_EQ(MEMKIND_ERROR_INVALID, err);
     EXPECT_TRUE(nullptr == pmem_kind_not_possible);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemDestroyKind)
+{
+    const size_t pmem_array_size = 10;
+    struct memkind *pmem_kind_array[pmem_array_size] = {nullptr};
+
+    int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE,
+                                  &pmem_kind_array[0]);
+    EXPECT_EQ(err, 0);
+
+    err = memkind_destroy_kind(pmem_kind_array[0]);
+    EXPECT_EQ(err, 0);
+
+    for (unsigned int i = 0; i < pmem_array_size; ++i) {
+        err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_kind_array[i]);
+        EXPECT_EQ(err, 0);
+    }
+
+    char *pmem_middle_name = pmem_kind_array[5]->name;
+    err = memkind_destroy_kind(pmem_kind_array[5]);
+    EXPECT_EQ(err, 0);
+
+    err = memkind_destroy_kind(pmem_kind_array[6]);
+    EXPECT_EQ(err, 0);
+
+    err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_kind_array[5]);
+    EXPECT_EQ(err, 0);
+
+    char *pmem_new_middle_name = pmem_kind_array[5]->name;
+
+    EXPECT_STREQ(pmem_middle_name, pmem_new_middle_name);
+
+    for (unsigned int i = 0; i < pmem_array_size; ++i) {
+        if (i != 6) {
+            err = memkind_destroy_kind(pmem_kind_array[i]);
+            EXPECT_EQ(err, 0);
+        }
+    }
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemDestroyKindArenaZero)
+{
+    struct memkind *pmem_temp_1 = nullptr;
+    struct memkind *pmem_temp_2 = nullptr;
+    unsigned int arena_zero = 0;
+    int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp_1);
+    EXPECT_EQ(err, 0);
+
+    arena_zero = pmem_temp_1->arena_zero;
+    err = memkind_destroy_kind(pmem_temp_1);
+    EXPECT_EQ(err, 0);
+    err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp_2);
+    EXPECT_EQ(err, 0);
+
+    EXPECT_EQ(arena_zero,pmem_temp_2->arena_zero);
+
+    err = memkind_destroy_kind(pmem_temp_2);
+    EXPECT_EQ(err, 0);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCreateDestroyKindLoop)
+{
+    struct memkind *pmem_temp = nullptr;
+    const size_t pmem_number = 25000;
+
+    for (unsigned int i = 0; i < pmem_number; ++i) {
+        int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
+        EXPECT_EQ(err, 0);
+        err = memkind_destroy_kind(pmem_temp);
+        EXPECT_EQ(err, 0);
+    }
+}
+
+TEST_F(MemkindPmemTests,
+       test_TC_MEMKIND_PmemCreateDestroyKindLoopWithMallocSmallSize)
+{
+    struct memkind *pmem_temp = nullptr;
+    const size_t pmem_number = 25000;
+    const size_t size = 1024;
+
+    for (unsigned int i = 0; i < pmem_number; ++i) {
+        int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
+        EXPECT_EQ(err, 0);
+        void *ptr = memkind_malloc(pmem_temp, size);
+        EXPECT_TRUE(nullptr != ptr);
+        memkind_free(pmem_temp, ptr);
+        err = memkind_destroy_kind(pmem_temp);
+        EXPECT_EQ(err, 0);
+    }
+}
+
+TEST_F(MemkindPmemTests,
+       test_TC_MEMKIND_PmemCreateDestroyKindLoopWithMallocChunkSize)
+{
+    struct memkind *pmem_temp = nullptr;
+    const size_t pmem_number = 25000;
+    const size_t size = MEMKIND_PMEM_CHUNK_SIZE;
+
+    for (unsigned int i = 0; i < pmem_number; ++i) {
+        int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
+        EXPECT_EQ(err, 0);
+        void *ptr = memkind_malloc(pmem_temp, size);
+        EXPECT_TRUE(nullptr != ptr);
+        memkind_free(pmem_temp, ptr);
+        err = memkind_destroy_kind(pmem_temp);
+        EXPECT_EQ(err, 0);
+    }
+}
+
+TEST_F(MemkindPmemTests,
+       test_TC_MEMKIND_PmemCreateDestroyKindLoopWithRealloc)
+{
+    struct memkind *pmem_temp = nullptr;
+    const size_t pmem_number = 25000;
+    const size_t size_1 = 512;
+    const size_t size_2 = 1024;
+
+    for (unsigned int i = 0; i < pmem_number; ++i) {
+        int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
+        EXPECT_EQ(err, 0);
+        void *ptr = memkind_malloc(pmem_temp, size_1);
+        EXPECT_TRUE(nullptr != ptr);
+        void *ptr_2 = memkind_realloc(pmem_temp, ptr, size_2);
+        EXPECT_TRUE(nullptr != ptr_2);
+        memkind_free(pmem_temp, ptr_2);
+        err = memkind_destroy_kind(pmem_temp);
+        EXPECT_EQ(err, 0);
+    }
 }


### PR DESCRIPTION
update partition_map in case of destroy kind
Ref: #57
Besides changes described in issue - cleaning memkind_registry_g.partition_map, there are two additonal changes:
-in memkind_arena_create_map after calling arenas.create - jemalloc could return arena_index in ascending or descending order - the change here is need to detect both cases  (test_TC_MEMKIND_PmemDestroyKindArenaZero cover this case )
-munmap must be called in pmem_extent_dalloc to unmap created arenas and in pmem_extent_destroy to unmap memory maped by memkind_pmem_mmap 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/64)
<!-- Reviewable:end -->
