### PR TITLE
Introduce C++ allocator for PMEM

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -27,6 +27,7 @@ examples/memkind_allocated_example.cpp
 examples/memkind_allocated.hpp
 examples/memkind_decorator_debug.c
 examples/pmem_example.c
+examples/pmem_cpp_allocator.cpp
 install_astyle.sh
 m4/ax_cxx_compile_stdcxx.m4
 m4/ax_cxx_compile_stdcxx_11.m4
@@ -59,6 +60,7 @@ include/hbwmalloc.h
 include/memkind.h
 include/memkind_deprecated.h
 include/hbw_allocator.h
+include/pmem_allocator.h
 include/memkind/internal/heap_manager.h
 include/memkind/internal/memkind_arena.h
 include/memkind/internal/memkind_default.h
@@ -171,6 +173,7 @@ test/freeing_memory_segfault_test.cpp
 test/dlopen_test.cpp
 test/gtest_fused/gtest/gtest-all.cc
 test/gtest_fused/gtest/gtest.h
+test/pmem_allocator_tests.cpp
 jemalloc/.appveyor.yml
 jemalloc/.autom4te.cfg
 jemalloc/.gitattributes

--- a/copying_headers/MANIFEST.freeBSD
+++ b/copying_headers/MANIFEST.freeBSD
@@ -17,6 +17,7 @@ examples/memkind_allocated_example.cpp
 examples/memkind_allocated.hpp
 examples/hello_memkind_example.c
 examples/memkind_decorator_debug.c
+examples/pmem_cpp_allocator.cpp
 man/autohbw.7
 man/hbwmalloc.3
 man/memkind.3
@@ -43,6 +44,7 @@ include/hbwmalloc.h
 include/memkind.h
 include/memkind_deprecated.h
 include/hbw_allocator.h
+include/pmem_allocator.h
 include/memkind/internal/heap_manager.h
 include/memkind/internal/memkind_arena.h
 include/memkind/internal/memkind_default.h
@@ -146,6 +148,7 @@ test/load_tbbmalloc_symbols.c
 test/tbbmalloc.h
 test/freeing_memory_segfault_test.cpp
 test/dlopen_test.cpp
+test/pmem_allocator_tests.cpp
 man/memkind_pmem.3
 src/memkind_pmem.c
 

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014 - 2016 Intel Corporation.
+#  Copyright (C) 2014 - 2018 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@ noinst_PROGRAMS += examples/hello_memkind \
                    # end
 if HAVE_CXX11
 noinst_PROGRAMS += examples/memkind_allocated
+noinst_PROGRAMS += examples/pmem_cpp_allocator
 endif
 
 examples_hello_memkind_LDADD = libmemkind.la
@@ -42,6 +43,7 @@ examples_autohbw_candidates_LDADD = libmemkind.la
 
 if HAVE_CXX11
 examples_memkind_allocated_LDADD = libmemkind.la
+examples_pmem_cpp_allocator_LDADD = libmemkind.la
 endif
 
 examples_hello_memkind_SOURCES = examples/hello_memkind_example.c
@@ -52,4 +54,5 @@ examples_pmem_memkind_SOURCES = examples/pmem_example.c
 examples_autohbw_candidates_SOURCES = examples/autohbw_candidates.c
 if HAVE_CXX11
 examples_memkind_allocated_SOURCES = examples/memkind_allocated_example.cpp examples/memkind_allocated.hpp
+examples_pmem_cpp_allocator_SOURCES = examples/pmem_cpp_allocator.cpp
 endif

--- a/examples/pmem_cpp_allocator.cpp
+++ b/examples/pmem_cpp_allocator.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2018 Intel Corporation.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice(s),
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice(s),
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "pmem_allocator.h"
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <array>
+#include <list>
+#include <map>
+#include <utility>
+#include <string>
+#include <algorithm>
+#include <scoped_allocator>
+#include <cassert>
+
+#define STL_VECTOR_TEST
+#define STL_LIST_TEST
+#if _GLIBCXX_USE_CXX11_ABI
+#define STL_VEC_STRING_TEST
+#define STL_MAP_INT_STRING_TEST
+#endif
+
+void cpp_allocator_test()
+{
+    std::cout << "TEST SCOPE: HELLO" << std::endl;
+
+    const char* pmem_directory = "/dev/shm";
+    size_t pmem_max_size = 1024*1024*1024;
+
+    /*
+     * Because of the issue #57 we cannot create multiple PMEM kinds.
+     * Therefore, we create alloc_source object of pmem::allocator class
+     * and use this object to copy-construct all other required allocators.
+     * In this case all allocators use the same PMEM kind created inside alloc_source object.
+     * When the issue #57 is fixed, we can remove alloc_source allocator
+     * and create required allocators from scratch.
+     */
+
+    pmem::allocator<int> alloc_source { pmem_directory, pmem_max_size } ;
+
+#ifdef STL_VECTOR_TEST
+    {
+        std::cout << "VECTOR OPEN" << std::endl;
+        pmem::allocator<int> alc{ alloc_source  };
+        std::vector<int, pmem::allocator<int>> vector{ alc };
+
+        for (int i = 0; i < 20; ++i) {
+            vector.push_back(0xDEAD + i);
+            assert(vector.back() == 0xDEAD + i);
+
+        }
+
+        std::cout << "VECTOR CLOSE" << std::endl;
+    }
+#endif
+
+#ifdef STL_LIST_TEST
+    {
+        std::cout << "LIST OPEN" << std::endl;
+        pmem::allocator<int> alc{ alloc_source };
+        std::list<int, pmem::allocator<int>> list{ alc };
+
+        const int nx2 = 4;
+        for (int i = 0; i < nx2; ++i) {
+            list.emplace_back(0xBEAC011 + i);
+            assert(list.back() == 0xBEAC011 + i);
+        }
+
+        for (int i = 0; i < nx2; ++i) {
+            list.pop_back();
+        }
+
+        std::cout << "LIST CLOSE" << std::endl;
+    }
+#endif
+
+#ifdef STL_VEC_STRING_TEST
+    {
+        std::cout << "STRINGED VECTOR OPEN" << std::endl;
+        typedef pmem::allocator<char> str_alloc_t;
+        typedef std::basic_string<char, std::char_traits<char>, str_alloc_t>
+        pmem_string;
+        typedef pmem::allocator<pmem_string> vec_alloc_t;
+
+        vec_alloc_t vec_alloc{ alloc_source };
+        str_alloc_t str_alloc{ alloc_source };
+
+        std::vector<pmem_string, std::scoped_allocator_adaptor<vec_alloc_t> > vec{ std::scoped_allocator_adaptor<vec_alloc_t>(vec_alloc) };
+
+        pmem_string arg{ "Very very loooong striiiing", str_alloc };
+
+        vec.push_back(arg);
+        assert(vec.back() == arg);
+
+        std::cout << "STRINGED VECTOR CLOSE" << std::endl;
+    }
+
+#endif
+
+#ifdef STL_MAP_INT_STRING_TEST
+    {
+        std::cout << "INT_STRING MAP OPEN" << std::endl;
+        typedef std::basic_string<char, std::char_traits<char>, pmem::allocator<char> >
+        pmem_string;
+        typedef int key_t;
+        typedef pmem_string value_t;
+        typedef std::pair<key_t, value_t> target_pair;
+        typedef pmem::allocator<target_pair> pmem_alloc;
+        typedef pmem::allocator<char> str_allocator_t;
+        typedef std::map<key_t, value_t, std::less<key_t>, std::scoped_allocator_adaptor<pmem_alloc> >
+        map_t;
+
+        pmem_alloc map_allocator( alloc_source );
+
+        str_allocator_t str_allocator( map_allocator );
+
+        value_t source_str1( "Lorem ipsum dolor ", str_allocator);
+        value_t source_str2( "sit amet consectetuer adipiscing elit", str_allocator );
+
+        map_t target_map{ std::scoped_allocator_adaptor<pmem_alloc>(map_allocator) };
+
+        target_map[key_t(165)] = source_str1;
+        assert(target_map[key_t(165)] == source_str1);
+        target_map[key_t(165)] = source_str2;
+        assert(target_map[key_t(165)] == source_str2);
+
+        std::cout << "INT_STRING MAP CLOSE" << std::endl;
+    }
+#endif
+    std::cout << "TEST SCOPE: GOODBYE" << std::endl;
+}
+
+int main()
+{
+    cpp_allocator_test();
+    return 0;
+}

--- a/include/pmem_allocator.h
+++ b/include/pmem_allocator.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2018 Intel Corporation.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice(s),
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice(s),
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <exception>
+#include <type_traits>
+#include <cstddef>
+#include <utility>
+#include <atomic>
+
+#include "memkind.h"
+
+namespace pmem
+{
+    template<typename T>
+    struct allocator {
+        typedef T value_type;
+        typedef value_type* pointer;
+        typedef const value_type* const_pointer;
+        typedef value_type& reference;
+        typedef const value_type& const_reference;
+        typedef size_t size_type;
+        typedef ptrdiff_t difference_type;
+
+        template<class U>
+        struct rebind {
+            typedef allocator<U> other;
+        };
+
+        template<typename U>
+        friend struct allocator;
+
+    private:
+        memkind_t kind_ptr;
+        std::atomic<size_t> * kind_cnt;
+
+        void clean_up()
+        {
+            if (kind_cnt->fetch_sub(1) == 1) {
+
+                memkind_destroy_kind(kind_ptr);
+                delete kind_cnt;
+            }
+        }
+
+        template <typename U>
+        inline void assign(U&&  other)
+        {
+            kind_ptr = other.kind_ptr;
+            kind_cnt = other.kind_cnt;
+            ++(*kind_cnt);
+        }
+
+    public:
+#ifndef _GLIBCXX_USE_CXX11_ABI
+        /* This is a workaround for compilers that uses C++11 standard,
+         * but use old - non C++11 ABI */
+        template<typename V = void>
+        explicit allocator()
+        {
+            static_assert(std::is_same<V, void>::value,
+                          "pmem::allocator cannot be compiled without CXX11 ABI");
+        }
+#endif
+
+        explicit allocator(const char *dir, size_t max_size)
+        {
+            int err_c  = memkind_create_pmem(dir, max_size, &kind_ptr);
+            if (err_c) {
+                throw std::runtime_error(
+                    std::string("An error occured while creating pmem kind; error code: ") +
+                    std::to_string(err_c));
+            }
+            kind_cnt = new std::atomic<size_t>(1);
+        }
+
+        explicit allocator(const std::string& dir,
+                           size_t max_size) : allocator(dir.c_str(), max_size)
+        {
+        };
+
+        allocator(const allocator& other) noexcept
+        {
+            assign(other);
+        }
+
+        template <typename U>
+        allocator(const allocator<U>& other) noexcept
+        {
+            assign(other);
+        }
+
+        allocator(const allocator&& other) noexcept
+        {
+            assign(other);
+        }
+
+        template <typename U>
+        allocator(const allocator<U>&& other) noexcept
+        {
+            assign(other);
+        }
+
+        void operator = (const allocator& other) noexcept
+        {
+            clean_up();
+            assign(other);
+        }
+
+        template <typename U>
+        void operator = (const allocator<U>& other) noexcept
+        {
+            clean_up();
+            assign(other);
+        }
+
+        void operator = (const allocator&& other) noexcept
+        {
+            clean_up();
+            assign(other);
+        }
+
+        template <typename U>
+        void operator = (const allocator<U>&& other) noexcept
+        {
+            clean_up();
+            assign(other);
+        }
+
+        template <typename U>
+        bool operator ==(const allocator<U>& other) const
+        {
+            return kind_ptr == other.kind_ptr;
+        }
+
+        template <typename U>
+        bool operator !=(const allocator<U>& other) const
+        {
+            return !(*this ==other);
+        }
+
+        T* allocate(std::size_t n) const
+        {
+            void* mptr = memkind_calloc(kind_ptr, n, sizeof(T));
+            return static_cast<T*>(mptr);
+        }
+
+        void deallocate(T* const p, std::size_t n) const
+        {
+            memkind_free(kind_ptr, static_cast<void*>(p));
+        }
+
+        template <class U, class... Args>
+        void construct(U* p, Args... args) const
+        {
+            ::new((void *)p) U(std::forward<Args>(args)...);
+        }
+
+        void destroy(T* const p) const
+        {
+            p->~value_type();
+        }
+
+        ~allocator()
+        {
+            clean_up();
+        }
+    };
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -95,6 +95,7 @@ test_all_tests_SOURCES = $(fused_gtest) \
                          test/static_kinds_tests.cpp \
                          test/hbw_verify_function_test.cpp \
                          test/dlopen_test.cpp \
+                         test/pmem_allocator_tests.cpp \
                          #end
 
 test_locality_test_SOURCES = $(fused_gtest) test/allocator_perf_tool/Allocation_info.cpp test/locality_test.cpp

--- a/test/pmem_allocator_tests.cpp
+++ b/test/pmem_allocator_tests.cpp
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2018 Intel Corporation.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice(s),
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice(s),
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pmem_allocator.h"
+#include "common.h"
+#include <vector>
+#include <memory>
+#include <array>
+#include <list>
+#include <map>
+#include <utility>
+#include <string>
+#include <algorithm>
+#include <scoped_allocator>
+#include <thread>
+
+// Tests for pmem::allocator class.
+class PmemAllocatorTests: public :: testing::Test
+{
+
+public:
+    static constexpr const char* PMEM_DIR = "/tmp/";
+    const size_t pmem_max_size = 1024*1024*1024;
+
+    pmem::allocator<int> alloc_source { std::string(PMEM_DIR), pmem_max_size } ;
+
+    pmem::allocator<int> alloc_source_f1 { std::string(PMEM_DIR), pmem_max_size } ;
+    pmem::allocator<int> alloc_source_f2 { std::string(PMEM_DIR), pmem_max_size } ;
+
+protected:
+    void SetUp()
+    {}
+
+    void TearDown()
+    {}
+
+};
+
+
+//Compare two same kind different type allocators
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_AllocatorCompare_SameKindDifferentType_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<char> alc2 { alloc_source_f1  };
+    ASSERT_TRUE(alc1 == alc2);
+    ASSERT_FALSE(alc1 != alc2);
+}
+
+//Compare two same kind same type
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_AllocatorCompare_SameKindSameType_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<int> alc2 { alloc_source_f1  };
+    ASSERT_TRUE(alc1 == alc2);
+    ASSERT_FALSE(alc1 != alc2);
+}
+
+//Compare two different kind different type
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_AllocatorCompare_DifferentKindDifferentType_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<char> alc2 { alloc_source_f2  };
+    ASSERT_FALSE(alc1 == alc2);
+    ASSERT_TRUE(alc1 != alc2);
+}
+
+//Compare two different kind same type allocators
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_AllocatorCompare_DifferentKindSameType_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<int> alc2 { alloc_source_f2  };
+    ASSERT_FALSE(alc1 == alc2);
+    ASSERT_TRUE(alc1 != alc2);
+}
+
+//Copy assignment test
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_Allocator_CopyAssignment_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<int> alc2 { alloc_source_f2  };
+    ASSERT_TRUE(alc1 != alc2);
+    alc1 = alc2;
+    ASSERT_TRUE(alc1 == alc2);
+}
+
+//Move constructor test
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_Allocator_MoveConstructor_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f2  };
+    pmem::allocator<int> alc2 { alloc_source_f2  };
+    ASSERT_TRUE(alc2 == alc1);
+    pmem::allocator<int> alc3 = std::move(alc1);
+    ASSERT_TRUE(alc2 == alc3);
+}
+
+//Move assignment test
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_Allocator_MoveAssignment_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<int> alc2 { alloc_source_f2  };
+    ASSERT_TRUE(alc1 != alc2);
+
+    {
+        pmem::allocator<int> alc3 { alc2  };
+        alc1 = std::move(alc3);
+    }
+    ASSERT_TRUE(alc1 == alc2);
+}
+
+//Single allocation-deallocation test
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_Allocator_SingleAllocationDeallocation_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    int* created_object = alc1.allocate(1);
+    alc1.deallocate(created_object, 1);
+}
+
+//Shared cross-allocation-deallocation test
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_Allocator_SharedAllocationDeallocation_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    pmem::allocator<int> alc2 { alloc_source_f1  };
+    int* created_object = nullptr;
+    int* created_object_2 = nullptr;
+    created_object = alc1.allocate(1);
+    ASSERT_TRUE(alc1 == alc2);
+    alc2.deallocate(created_object, 1);
+    created_object = alc2.allocate(1);
+    alc1.deallocate(created_object, 1);
+
+    created_object = alc1.allocate(1);
+    created_object_2 = alc2.allocate(1);
+    alc2.deallocate(created_object, 1);
+    alc1.deallocate(created_object_2, 1);
+}
+
+//Construct-destroy test
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_Allocator_ConsructDestroy_Test)
+{
+    pmem::allocator<int> alc1 { alloc_source_f1  };
+    int* created_object = alc1.allocate(1);
+    alc1.construct(created_object);
+    alc1.destroy(created_object);
+}
+
+//Testing thread-safety support
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_Allocator_MultithreadingSupport_Test)
+{
+    const size_t num_threads = 1000;
+    const size_t iteration_count = 5000;
+
+    std::vector<std::thread> thds;
+    for (size_t i = 0; i < num_threads; ++i) {
+
+        thds.push_back(std::thread( [&]() {
+            std::vector<pmem::allocator<int>> allocators_local;
+            for (size_t j = 0; j < iteration_count; j++) {
+                allocators_local.push_back(pmem::allocator<int> ( alloc_source ));
+            }
+            for (size_t j = 0; j < iteration_count; j++) {
+                allocators_local.pop_back();
+            }
+        })
+                      );
+    }
+
+    for (size_t i = 0; i < num_threads; ++i) {
+        thds[i].join();
+    }
+}
+
+//Test multiple memkind allocator usage
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_MultipleAllocatorUsage_Test)
+{
+    {
+        pmem::allocator<int> alloc { PMEM_DIR, pmem_max_size } ;
+    }
+
+    {
+        pmem::allocator<int> alloc { PMEM_DIR, pmem_max_size } ;
+    }
+}
+
+//Test vector
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_AllocatorUsage_Vector_Test)
+{
+    pmem::allocator<int> alc{ alloc_source  };
+    std::vector<int, pmem::allocator<int>> vector{ alc };
+
+    for (int i = 0; i < 20; ++i) {
+        vector.push_back(0xDEAD + i);
+    }
+
+    for (int i = 0; i < 20; ++i) {
+        ASSERT_TRUE(vector[i] == 0xDEAD + i);
+    }
+}
+
+//Test list
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_AllocatorUsage_List_Test)
+{
+    pmem::allocator<int> alc{ alloc_source };
+
+    std::list<int, pmem::allocator<int>> list{ alc };
+
+    const int nx2 = 4;
+
+    for (int i = 0; i < nx2; ++i) {
+        list.emplace_back(0xBEAC011 + i);
+        ASSERT_TRUE(list.back() == 0xBEAC011 + i);
+    }
+
+    for (int i = 0; i < nx2; ++i) {
+        list.pop_back();
+    }
+}
+
+//Test map
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_AllocatorUsage_Map_Test)
+{
+    pmem::allocator<std::pair<const std::string, std::string>> alc{ alloc_source };
+
+    std::map<std::string, std::string, std::less<std::string>, pmem::allocator<std::pair<const std::string, std::string> > >
+    map{ std::less<std::string>(), alc };
+
+    for (int i = 0; i < 10; ++i) {
+        map[std::to_string(i)] = std::to_string(0x0CEA11 + i);
+        ASSERT_TRUE(map[std::to_string(i)] == std::to_string(0x0CEA11 + i));
+        map[std::to_string((i * 997 + 83) % 113)] = std::to_string(0x0CEA11 + i);
+        ASSERT_TRUE(map[std::to_string((i * 997 + 83) % 113)] == std::to_string(
+                        0x0CEA11 + i));
+    }
+}
+
+#if _GLIBCXX_USE_CXX11_ABI
+//Test vector of strings
+TEST_F(PmemAllocatorTests, test_TC_MEMKIND_AllocatorUsage_VectorOfString_Test)
+{
+    typedef std::basic_string<char, std::char_traits<char>, pmem::allocator<char>>
+                                                                                pmem_string;
+    typedef pmem::allocator<pmem_string> pmem_alloc;
+
+    pmem_alloc alc{ alloc_source };
+    pmem::allocator<char> st_alc{alc};
+
+    std::vector<pmem_string,std::scoped_allocator_adaptor<pmem_alloc> > vec{ alc };
+    pmem_string arg{ "Very very loooong striiiing", st_alc };
+
+    vec.push_back(arg);
+    ASSERT_TRUE(vec.back() == arg);
+}
+
+//Test map of int strings
+TEST_F(PmemAllocatorTests,
+       test_TC_MEMKIND_AllocatorScopedUsage_MapOfIntString_Test)
+{
+    typedef std::basic_string<char, std::char_traits<char>, pmem::allocator<char> >
+    pmem_string;
+    typedef int key_t;
+    typedef pmem_string value_t;
+    typedef std::pair<key_t, value_t> target_pair;
+    typedef pmem::allocator<target_pair> pmem_alloc;
+    typedef pmem::allocator<char> str_allocator_t;
+    typedef std::map<key_t, value_t, std::less<key_t>, std::scoped_allocator_adaptor<pmem_alloc> >
+    map_t;
+
+    pmem_alloc map_allocator( alloc_source );
+
+    str_allocator_t str_allocator( map_allocator );
+
+    value_t source_str1( "Lorem ipsum dolor ", str_allocator);
+    value_t source_str2( "sit amet consectetuer adipiscing elit", str_allocator );
+
+    map_t target_map{ std::scoped_allocator_adaptor<pmem_alloc>(map_allocator) };
+
+    target_map[key_t(165)] = source_str1;
+    ASSERT_TRUE(target_map[key_t(165)] == source_str1);
+    target_map[key_t(165)] = source_str2;
+    ASSERT_TRUE(target_map[key_t(165)] == source_str2);
+}
+#endif // _GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
We have created STL-like C++ allocator for PMEM kind.
This allocator could be used with any STL-like data structures.
We created set of test and examples for STL data structures.
Also, we tested this allocator privately with Intel TBB data structures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/67)
<!-- Reviewable:end -->
