### PR TITLE
Fix warning unrecognized option: --disable-valgrind

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -58,7 +58,7 @@ a) Building jemalloc
 
 The memkind library has a dependency on a related fork of jemalloc.
 
-The jemalloc source was forked from jemalloc version 4.5. This source tree
+The jemalloc source was forked from jemalloc version 5.0. This source tree
 is located within the jemalloc subdirectory of the memkind source. The jemalloc
 source code has been kept close to the original form, and in particular,
 the build system has been lightly modified.

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -75,7 +75,7 @@ Alternatively you can follow this step-by-step instruction:
     mkdir obj
     cd obj
     ../configure --enable-autogen --with-jemalloc-prefix=jemk_ --without-export \
-                 --disable-stats --disable-fill --disable-valgrind \
+                 --disable-stats --disable-fill \
                  --with-malloc-conf="lg_chunk:22"
     make
     cd ../..

--- a/build_jemalloc.sh
+++ b/build_jemalloc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright (C) 2016 Intel Corporation.
+#  Copyright (C) 2016 - 2018 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@ test -e configure || autoconf
 test -e obj || mkdir obj
 cd obj
 ../configure --enable-autogen --with-jemalloc-prefix=$JE_PREFIX --without-export \
-             --disable-stats --disable-fill --disable-valgrind \
+             --disable-stats --disable-fill \
              $EXTRA_CONF --with-malloc-conf="narenas:256,lg_tcache_max:12"
 
 make -j`nproc`


### PR DESCRIPTION
Remove warning: 
"configure: WARNING: unrecognized options: --disable-valgrind"

Valgrind support was removed in jemalloc 5.0 ( see https://github.com/jemalloc/jemalloc/releases )
Jemalloc version which is used in memkind was switched to 5.0 in cebc254b258a9a36df8bfc681994b19bc37042d0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/74)
<!-- Reviewable:end -->
