### PR TITLE
Fix memory leak in case of ops->create fail

### DIFF
--- a/src/memkind.c
+++ b/src/memkind.c
@@ -487,6 +487,7 @@ static int memkind_create(struct memkind_ops *ops, const char *name,
     (*kind)->partition = memkind_registry_g.num_kind;
     err = ops->create(*kind, ops, name);
     if (err) {
+        jemk_free(*kind);
         goto exit;
     }
     memkind_registry_g.partition_map[id_kind] = *kind;


### PR DESCRIPTION
Release the memory of previously initialized kind ( https://github.com/memkind/memkind/blob/22a80b661a7010d897b77082358665f25d8f2880/src/memkind.c#L480)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/89)
<!-- Reviewable:end -->
