### PR TITLE
Minor changes related to test/examples sections

### DIFF
--- a/copying_headers/MANIFEST.freeBSD
+++ b/copying_headers/MANIFEST.freeBSD
@@ -17,7 +17,6 @@ examples/memkind_allocated_example.cpp
 examples/memkind_allocated.hpp
 examples/hello_memkind_example.c
 examples/memkind_decorator_debug.c
-examples/pmem_cpp_allocator.cpp
 man/autohbw.7
 man/hbwmalloc.3
 man/memkind.3

--- a/copying_headers/MANIFEST.freeBSD3
+++ b/copying_headers/MANIFEST.freeBSD3
@@ -5,3 +5,4 @@ examples/pmem_usable_size.c
 examples/pmem_alignment.c
 examples/pmem_multithreads.c
 examples/pmem_multithreads_onekind.c
+examples/pmem_cpp_allocator.cpp

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ interface.
 
 ## PMEM
 
-The pmem_*.c demonstrates how to create and use a file-backed memory kind.
+The pmem_*.c(pp) demonstrates how to create and use a file-backed memory kind.
 The default pmem path is "/tmp/".
 Custom directory is pass as first argument to all of PMEM example programs, e.g. to execute pmem_malloc example in /mnt/pmem location, call:
 
@@ -38,6 +38,11 @@ This example shows how to use multithreading with independent pmem kinds.
 ### pmem_multithreads_onekind.c
 
 This example shows how to use multithreading with one main pmem kind.
+
+### pmem_cpp_allocator.cpp
+
+This example shows usage of C++ allocator mechanism designed for file-backed memory
+kind with different data structures like: vector, list and map.
 
 ## Other memkind examples
 

--- a/examples/pmem_cpp_allocator.cpp
+++ b/examples/pmem_cpp_allocator.cpp
@@ -1,25 +1,33 @@
 /*
- * Copyright (C) 2018 Intel Corporation.
- * All rights reserved.
+ * Copyright (c) 2018 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 1. Redistributions of source code must retain the above copyright notice(s),
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice(s),
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * modification, are permitted provided that the following conditions
+ * are met:
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
- * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
- * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -86,11 +86,11 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPriv)
     ASSERT_TRUE(total_mem != 0);
     ASSERT_TRUE(free_mem != 0);
 
-    EXPECT_EQ(total_mem, roundup(PMEM_PART_SIZE, MEMKIND_PMEM_CHUNK_SIZE));
+    ASSERT_EQ(total_mem, roundup(PMEM_PART_SIZE, MEMKIND_PMEM_CHUNK_SIZE));
 
     size_t offset = total_mem - free_mem;
-    EXPECT_LT(offset, MEMKIND_PMEM_CHUNK_SIZE);
-    EXPECT_LT(offset, total_mem);
+    ASSERT_LT(offset, MEMKIND_PMEM_CHUNK_SIZE);
+    ASSERT_LT(offset, total_mem);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMalloc)
@@ -99,7 +99,7 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMalloc)
     char *default_str = nullptr;
 
     default_str = (char *)memkind_malloc(pmem_kind, size);
-    EXPECT_TRUE(nullptr != default_str);
+    ASSERT_TRUE(nullptr != default_str);
 
     sprintf(default_str, "memkind_malloc MEMKIND_PMEM\n");
     printf("%s", default_str);
@@ -108,7 +108,7 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMalloc)
 
     // Out of memory
     default_str = (char *)memkind_malloc(pmem_kind, 2 * PMEM_PART_SIZE);
-    EXPECT_EQ(nullptr, default_str);
+    ASSERT_EQ(nullptr, default_str);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocZero)
@@ -136,8 +136,8 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCalloc)
     char *default_str = nullptr;
 
     default_str = (char *)memkind_calloc(pmem_kind, num, size);
-    EXPECT_TRUE(nullptr != default_str);
-    EXPECT_EQ(*default_str, 0);
+    ASSERT_TRUE(nullptr != default_str);
+    ASSERT_EQ(*default_str, 0);
 
     sprintf(default_str, "memkind_calloc MEMKIND_PMEM\n");
     printf("%s", default_str);
@@ -146,8 +146,8 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCalloc)
 
     // allocate the buffer of the same size (likely at the same address)
     default_str = (char *)memkind_calloc(pmem_kind, num, size);
-    EXPECT_TRUE(nullptr != default_str);
-    EXPECT_EQ(*default_str, 0);
+    ASSERT_TRUE(nullptr != default_str);
+    ASSERT_EQ(*default_str, 0);
 
     sprintf(default_str, "memkind_calloc MEMKIND_PMEM\n");
     printf("%s", default_str);
@@ -206,8 +206,8 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCallocHuge)
     char *default_str = nullptr;
 
     default_str = (char *)memkind_calloc(pmem_kind, num, size);
-    EXPECT_TRUE(nullptr != default_str);
-    EXPECT_EQ(*default_str, 0);
+    ASSERT_TRUE(nullptr != default_str);
+    ASSERT_EQ(*default_str, 0);
 
     sprintf(default_str, "memkind_calloc MEMKIND_PMEM\n");
     printf("%s", default_str);
@@ -216,8 +216,8 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCallocHuge)
 
     // allocate the buffer of the same size (likely at the same address)
     default_str = (char *)memkind_calloc(pmem_kind, num, size);
-    EXPECT_TRUE(nullptr != default_str);
-    EXPECT_EQ(*default_str, 0);
+    ASSERT_TRUE(nullptr != default_str);
+    ASSERT_EQ(*default_str, 0);
 
     sprintf(default_str, "memkind_calloc MEMKIND_PMEM\n");
     printf("%s", default_str);
@@ -232,13 +232,13 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemRealloc)
     char *default_str = nullptr;
 
     default_str = (char *)memkind_realloc(pmem_kind, default_str, size1);
-    EXPECT_TRUE(nullptr != default_str);
+    ASSERT_TRUE(nullptr != default_str);
 
     sprintf(default_str, "memkind_realloc MEMKIND_PMEM with size %zu\n", size1);
     printf("%s", default_str);
 
     default_str = (char *)memkind_realloc(pmem_kind, default_str, size2);
-    EXPECT_TRUE(nullptr != default_str);
+    ASSERT_TRUE(nullptr != default_str);
 
     sprintf(default_str, "memkind_realloc MEMKIND_PMEM with size %zu\n", size2);
     printf("%s", default_str);
@@ -267,23 +267,24 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocUsableSize)
     struct memkind *pmem_temp = nullptr;
 
     int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
-    EXPECT_EQ(0, err);
-    EXPECT_TRUE(nullptr != pmem_temp);
+    ASSERT_EQ(0, err);
+    ASSERT_TRUE(nullptr != pmem_temp);
     size_t usable_size = memkind_malloc_usable_size(pmem_temp, nullptr);
-    EXPECT_EQ(0u, usable_size);
-    for (unsigned int i = 0; i < (sizeof(check_sizes) / sizeof(check_sizes[0]));
-         ++i) {
+    ASSERT_EQ(0u, usable_size);
+    for (unsigned int i = 0; i < ARRAY_SIZE(check_sizes); ++i) {
         size_t size = check_sizes[i].size;
         void *alloc = memkind_malloc(pmem_temp, size);
-        EXPECT_TRUE(nullptr != alloc);
+        ASSERT_TRUE(nullptr != alloc);
+
         usable_size = memkind_malloc_usable_size(pmem_temp, alloc);
         size_t diff = usable_size - size;
-        EXPECT_GE(usable_size, size);
-        EXPECT_LE(diff, check_sizes[i].spacing);
+        ASSERT_GE(usable_size, size);
+        ASSERT_LE(diff, check_sizes[i].spacing);
+
         memkind_free(pmem_temp, alloc);
     }
     err = memkind_destroy_kind(pmem_temp);
-    EXPECT_EQ(0, err);
+    ASSERT_EQ(0, err);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemResize)
@@ -296,35 +297,35 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemResize)
     int err = 0;
 
     pmem_str10 = (char *)memkind_malloc(pmem_kind, MEMKIND_PMEM_MIN_SIZE);
-    EXPECT_TRUE(nullptr != pmem_str10);
+    ASSERT_TRUE(nullptr != pmem_str10);
 
     // Out of memory
     pmem_strX = (char *)memkind_malloc(pmem_kind, size);
-    EXPECT_TRUE(nullptr == pmem_strX);
+    ASSERT_TRUE(nullptr == pmem_strX);
 
     memkind_free(pmem_kind, pmem_str10);
     memkind_free(pmem_kind, pmem_strX);
 
     err = memkind_create_pmem(PMEM_DIR, PMEM_NO_LIMIT, &pmem_kind_no_limit);
-    EXPECT_EQ(0, err);
-    EXPECT_TRUE(nullptr != pmem_kind_no_limit);
+    ASSERT_EQ(0, err);
+    ASSERT_TRUE(nullptr != pmem_kind_no_limit);
 
     pmem_str10 = (char *)memkind_malloc(pmem_kind_no_limit, MEMKIND_PMEM_MIN_SIZE);
-    EXPECT_TRUE(nullptr != pmem_str10);
+    ASSERT_TRUE(nullptr != pmem_str10);
 
     pmem_strX = (char *)memkind_malloc(pmem_kind_no_limit, size);
-    EXPECT_TRUE(nullptr != pmem_strX);
+    ASSERT_TRUE(nullptr != pmem_strX);
 
     memkind_free(pmem_kind_no_limit, pmem_str10);
     memkind_free(pmem_kind_no_limit, pmem_strX);
 
     err = memkind_destroy_kind(pmem_kind_no_limit);
-    EXPECT_EQ(0, err);
+    ASSERT_EQ(0, err);
 
     err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE-1,
                               &pmem_kind_not_possible);
-    EXPECT_EQ(MEMKIND_ERROR_INVALID, err);
-    EXPECT_TRUE(nullptr == pmem_kind_not_possible);
+    ASSERT_EQ(MEMKIND_ERROR_INVALID, err);
+    ASSERT_TRUE(nullptr == pmem_kind_not_possible);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocZero)
@@ -601,8 +602,9 @@ INSTANTIATE_TEST_CASE_P(
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocSmallSizeFill)
 {
     const size_t small_size[] = {8, 16, 32, 48, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384,
-                                 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2048, 2560,
-                                 3072, 3584, 4096, 5120, 6144, 7168, 8192, 10240, 12288, 14336
+                                 448, 512, 640, 768, 896, 1 * KB, 1280, 1536, 1792, 2 * KB, 2560,
+                                 3 * KB, 3584, 4 * KB, 5 * KB, 6 * KB, 7 * KB, 8 * KB, 10 * KB,
+                                 12 * KB, 14 * KB
                                 };
     const int malloc_limit = 10000;
     const int loop_limit = 100;
@@ -766,8 +768,8 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPosixMemalign)
                     break;
                 }
 
-                EXPECT_EQ(ret, 0);
-                EXPECT_EQ(errno, 0);
+                ASSERT_EQ(ret, 0);
+                ASSERT_EQ(errno, 0);
 
                 ptrs[j] = (int *)test;
 
@@ -845,34 +847,34 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemDestroyKind)
 
     int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE,
                                   &pmem_kind_array[0]);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
     err = memkind_destroy_kind(pmem_kind_array[0]);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
     for (unsigned int i = 0; i < pmem_array_size; ++i) {
         err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_kind_array[i]);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
     }
 
     char *pmem_middle_name = pmem_kind_array[5]->name;
     err = memkind_destroy_kind(pmem_kind_array[5]);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
     err = memkind_destroy_kind(pmem_kind_array[6]);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
     err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_kind_array[5]);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
     char *pmem_new_middle_name = pmem_kind_array[5]->name;
 
-    EXPECT_STREQ(pmem_middle_name, pmem_new_middle_name);
+    ASSERT_STREQ(pmem_middle_name, pmem_new_middle_name);
 
     for (unsigned int i = 0; i < pmem_array_size; ++i) {
         if (i != 6) {
             err = memkind_destroy_kind(pmem_kind_array[i]);
-            EXPECT_EQ(err, 0);
+            ASSERT_EQ(err, 0);
         }
     }
 }
@@ -883,18 +885,18 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemDestroyKindArenaZero)
     struct memkind *pmem_temp_2 = nullptr;
     unsigned int arena_zero = 0;
     int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp_1);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
     arena_zero = pmem_temp_1->arena_zero;
     err = memkind_destroy_kind(pmem_temp_1);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
     err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp_2);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 
-    EXPECT_EQ(arena_zero,pmem_temp_2->arena_zero);
+    ASSERT_EQ(arena_zero,pmem_temp_2->arena_zero);
 
     err = memkind_destroy_kind(pmem_temp_2);
-    EXPECT_EQ(err, 0);
+    ASSERT_EQ(err, 0);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCreateDestroyKindLoop)
@@ -903,9 +905,9 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCreateDestroyKindLoop)
 
     for (unsigned int i = 0; i < MEMKIND_MAX_KIND; ++i) {
         int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
         err = memkind_destroy_kind(pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
     }
 }
 
@@ -917,12 +919,12 @@ TEST_F(MemkindPmemTests,
 
     for (unsigned int i = 0; i < MEMKIND_MAX_KIND; ++i) {
         int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
         void *ptr = memkind_malloc(pmem_temp, size);
-        EXPECT_TRUE(nullptr != ptr);
+        ASSERT_TRUE(nullptr != ptr);
         memkind_free(pmem_temp, ptr);
         err = memkind_destroy_kind(pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
     }
 }
 
@@ -934,12 +936,12 @@ TEST_F(MemkindPmemTests,
 
     for (unsigned int i = 0; i < MEMKIND_MAX_KIND; ++i) {
         int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
         void *ptr = memkind_malloc(pmem_temp, size);
-        EXPECT_TRUE(nullptr != ptr);
+        ASSERT_TRUE(nullptr != ptr);
         memkind_free(pmem_temp, ptr);
         err = memkind_destroy_kind(pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
     }
 }
 
@@ -952,14 +954,14 @@ TEST_F(MemkindPmemTests,
 
     for (unsigned int i = 0; i < MEMKIND_MAX_KIND; ++i) {
         int err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
         void *ptr = memkind_malloc(pmem_temp, size_1);
-        EXPECT_TRUE(nullptr != ptr);
+        ASSERT_TRUE(nullptr != ptr);
         void *ptr_2 = memkind_realloc(pmem_temp, ptr, size_2);
-        EXPECT_TRUE(nullptr != ptr_2);
+        ASSERT_TRUE(nullptr != ptr_2);
         memkind_free(pmem_temp, ptr_2);
         err = memkind_destroy_kind(pmem_temp);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
     }
 }
 
@@ -973,13 +975,13 @@ TEST_F(MemkindPmemTests,
     for (i = 0; i < MEMKIND_MAX_KIND; ++i) {
         err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_temp[i]);
         if (err) {
-            EXPECT_EQ(err, MEMKIND_ERROR_ARENAS_CREATE);
+            ASSERT_EQ(err, MEMKIND_ERROR_ARENAS_CREATE);
             break;
         }
     }
     for (j = 0; j < i; ++j) {
         err = memkind_destroy_kind(pmem_temp[j]);
-        EXPECT_EQ(err, 0);
+        ASSERT_EQ(err, 0);
     }
 }
 


### PR DESCRIPTION
- clean-up pmem_test code - use ARRAY_SIZE/KB macro, use gtest ASSERT instead of EXPECT 
- use freeBSD3 license in pmem cpp allocator example, just like in other examples related to pmem
- update README with description of pmem_cpp_allocator example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/105)
<!-- Reviewable:end -->
