### PR TITLE
2 tests that fill and destroy kind without freeing it

### DIFF
--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -28,6 +28,7 @@
 
 #include <sys/param.h>
 #include <sys/mman.h>
+#include <sys/statfs.h>
 #include <stdio.h>
 #include <pthread.h>
 #include "common.h"
@@ -223,6 +224,61 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCallocHuge)
     printf("%s", default_str);
 
     memkind_free(pmem_kind, default_str);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeMemoryAfterDestroyLargeClass)
+{
+    memkind_t pmem_kind_test;
+    struct statfs st;
+    double blocksAvailable;
+
+    int err = memkind_create_pmem(PMEM_DIR, PMEM_PART_SIZE, &pmem_kind_test);
+    ASSERT_EQ(0, err);
+    ASSERT_TRUE(nullptr != pmem_kind_test);
+
+    ASSERT_EQ(0, statfs(PMEM_DIR, &st));
+    blocksAvailable = st.f_bfree;
+
+    while(1) {
+        if (memkind_malloc(pmem_kind_test, 16 * KB) == nullptr)
+            break;
+    }
+
+    ASSERT_EQ(0, statfs(PMEM_DIR, &st));
+    ASSERT_GT(blocksAvailable, st.f_bfree);
+
+    err = memkind_destroy_kind(pmem_kind_test);
+    ASSERT_EQ(0, err);
+
+    ASSERT_EQ(0, statfs(PMEM_DIR, &st));
+    ASSERT_EQ(blocksAvailable, st.f_bfree);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeMemoryAfterDestroySmallClass)
+{
+    memkind_t pmem_kind_test;
+    struct statfs st;
+    double blocksAvailable;
+
+    int err = memkind_create_pmem(PMEM_DIR, PMEM_PART_SIZE, &pmem_kind_test);
+    ASSERT_EQ(0, err);
+    ASSERT_TRUE(nullptr != pmem_kind_test);
+
+    ASSERT_EQ(0, statfs(PMEM_DIR, &st));
+    blocksAvailable = st.f_bfree;
+
+    for(int i = 0; i < 100; ++i) {
+        ASSERT_TRUE(memkind_malloc(pmem_kind_test, 32) != nullptr);
+    }
+
+    ASSERT_EQ(0, statfs(PMEM_DIR, &st));
+    ASSERT_GT(blocksAvailable, st.f_bfree);
+
+    err = memkind_destroy_kind(pmem_kind_test);
+    ASSERT_EQ(0, err);
+
+    ASSERT_EQ(0, statfs(PMEM_DIR, &st));
+    ASSERT_EQ(blocksAvailable, st.f_bfree);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemRealloc)


### PR DESCRIPTION
First test allocate 16*KB size kind until it runs out of space. After that destroys them and checks if the number of free blocks is the same as at the beginning of the test.

Second test loops 100 times allocating 32 bytes size kind. After that destroys them and check if the number of free blocks is the same as at the beginning of the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/112)
<!-- Reviewable:end -->
