### PR TITLE
Update memkind_create_pmem status in case of failure

### DIFF
--- a/man/hbwmalloc.3
+++ b/man/hbwmalloc.3
@@ -54,7 +54,7 @@ Note: hbwmalloc.h functionality is considered as stable API (STANDARD API).
 .fi
 .SH "DESCRIPTION"
 .BR hbw_check_available ()
-returns 0 if high bandwidth memory is available or an error code
+returns zero if high bandwidth memory is available or an error code
 described in the
 .B ERRORS
 section if not.

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -304,6 +304,9 @@ The
 passed in is the raw size of the memory pool and
 .B jemalloc
 will use some of that space for its own metadata.
+Returns zero if the pmem memkind is created successfully or an error code from the
+.B ERRORS
+section if not.
 .PP
 .BR memkind_create_kind ()
 creates kind that allocates memory with specific memory type, memory binding policy and flags (see
@@ -317,9 +320,7 @@ section) determine memory types to allocate,
 .IR policy
 argument is policy for specifying page binding to memory types selected by
 .IR memtype_flags .
-Returns
-.IR MEMKIND_SUCCESS
-if the specified kind is created successfully or an error code from the
+Returns zero if the specified kind is created successfully or an error code from the
 .B ERRORS
 section if not.
 .PP
@@ -333,7 +334,7 @@ and all allocated memory must be freed before kind is destroyed,
 otherwise this will cause memory leak.
 .PP
 .BR memkind_check_available ()
-returns a zero if the specified
+returns zero if the specified
 .I kind
 is available or an error code from the
 .B ERRORS
@@ -417,7 +418,10 @@ section upon failure.
 The memkind library avoids setting
 .I errno
 directly, but calls to underlying libraries and system calls may set
-.IR errno .
+.IR errno
+( e.g.
+.BR memkind_create_pmem ()
+).
 .SH "KINDS"
 The available kinds of memory:
 .TP

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -686,7 +686,8 @@ static int memkind_tmpfile(const char *dir, int *fd)
     int dir_len = strlen(dir);
 
     if (dir_len > PATH_MAX) {
-        return MEMKIND_ERROR_RUNTIME;
+        log_err("Could not create temporary file: too long path.");
+        return MEMKIND_ERROR_INVALID;
     }
 
     char fullname[dir_len + sizeof (template)];
@@ -698,7 +699,8 @@ static int memkind_tmpfile(const char *dir, int *fd)
     (void) sigprocmask(SIG_BLOCK, &set, &oldset);
 
     if ((*fd = mkstemp(fullname)) < 0) {
-        err = MEMKIND_ERROR_RUNTIME;
+        log_err("Could not create temporary file: errno=%d.", errno);
+        err = MEMKIND_ERROR_INVALID;
         goto exit;
     }
 
@@ -725,6 +727,7 @@ MEMKIND_EXPORT int memkind_create_pmem(const char *dir, size_t max_size,
     int oerrno;
 
     if (max_size && max_size < MEMKIND_PMEM_MIN_SIZE) {
+        log_err("Cannot create pmem: invalid size.");
         return MEMKIND_ERROR_INVALID;
     }
 


### PR DESCRIPTION
-update manual information about errno variable.
-change MEMKIND_ERROR_RUNTIME to MEMKIND_ERROR_INVALID
-replace undocumentd MEMKIND_SUCCESS with "zero"
-add log_err in case of failing to create pmem in passed directory
Ref: #108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/113)
<!-- Reviewable:end -->
