### PR TITLE
Log output added to test_TC_MEMKIND_PmemMallocSize

### DIFF
--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -28,9 +28,11 @@
 
 #include <sys/param.h>
 #include <sys/mman.h>
+#include <sys/statfs.h>
 #include <stdio.h>
 #include <pthread.h>
 #include "common.h"
+
 
 static const size_t PMEM_PART_SIZE = MEMKIND_PMEM_MIN_SIZE + 4 * KB;
 static const size_t PMEM_NO_LIMIT = 0;
@@ -555,6 +557,10 @@ TEST_P(MemkindPmemTestsMalloc, test_TC_MEMKIND_PmemMallocSize)
     int temp_limit_of_allocations = 0;
     void *test[malloc_limit] = {nullptr};
     int i = 0, j = 0;
+    FILE *fp;
+    char fileName[25] = "Log_PmemMallocSize.txt";
+    char logMessage[250] = "";
+    int tempLimitResults[10];
 
     //check maximum number of allocations right after create the kind
     for (i = 0; i < malloc_limit; i++) {
@@ -582,6 +588,7 @@ TEST_P(MemkindPmemTestsMalloc, test_TC_MEMKIND_PmemMallocSize)
         ASSERT_TRUE(malloc_limit != j);
 
         temp_limit_of_allocations = j;
+        tempLimitResults[i] = temp_limit_of_allocations;
 
         for (j = 0; j < temp_limit_of_allocations; j++) {
             memkind_free(pmem_kind, test[j]);
@@ -589,6 +596,18 @@ TEST_P(MemkindPmemTestsMalloc, test_TC_MEMKIND_PmemMallocSize)
         }
 
         ASSERT_TRUE(temp_limit_of_allocations > 0.98 * first_limit_of_allocations);
+    }
+
+    fp = fopen(fileName, "a+");
+    if (fp) {
+        sprintf(logMessage,
+                "Alloc size = %lu | Starting limit of alocations: %d | 1st: %d, 2nd: %d, 3rd: %d, 4th: %d, 5th: %d, 6th: %d, 7th: %d, 8th: %d, 9th: %d, 10th: %d\n",
+                GetParam(), first_limit_of_allocations, tempLimitResults[0],
+                tempLimitResults[1], tempLimitResults[2], tempLimitResults[3],
+                tempLimitResults[4], tempLimitResults[5], tempLimitResults[6],
+                tempLimitResults[7], tempLimitResults[8], tempLimitResults[9]);
+        fputs(logMessage, fp);
+        fclose(fp);
     }
 }
 


### PR DESCRIPTION
I have added log output to the test_TC_MEMKIND_PmemMallocSize. 
Log file name: Log_PmemMallocSize.txt

Each test is written to separate line which looks as follows:
"Alloc size = %lu | Starting limit of alocations: %d | 1st: %d, 2nd: %d, 3rd: %d, 4th: %d, 5th: %d, 6th: %d, 7th: %d, 8th: %d, 9th: %d, 10th: %d\n"

In case you need different log text please let me know how should it looks like. Also I don't know if it will be an issue but each test adds new line to the file so after 100 tests there will be 100 lines. Old logs are not replaced. It is related to that I don't know which test is the first and which is the last so it makes difficult to manipulate the file. Again please let me know if it is alright or I should think about the solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/116)
<!-- Reviewable:end -->
