### PR TITLE
Long time test update

### DIFF
--- a/test/memkind_pmem_long_time_tests.cpp
+++ b/test/memkind_pmem_long_time_tests.cpp
@@ -28,7 +28,6 @@
 
 #define STRESS_TIME (3*24*60*60)
 
-static const size_t PMEM_PART_SIZE = MEMKIND_PMEM_MIN_SIZE + 4 * KB;
 extern const char*  PMEM_DIR;
 
 static const size_t small_size[] = {8, 16, 32, 48, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384,
@@ -50,8 +49,7 @@ protected:
     memkind_t pmem_kind;
     void SetUp()
     {
-        // create PMEM partition
-        int err = memkind_create_pmem(PMEM_DIR, PMEM_PART_SIZE, &pmem_kind);
+        int err = memkind_create_pmem(PMEM_DIR, 0, &pmem_kind);
         ASSERT_EQ(0, err);
         ASSERT_TRUE(nullptr != pmem_kind);
     }
@@ -63,7 +61,7 @@ protected:
     }
 };
 
-TEST_F(MemkindPmemLongTimeStress, test_TC_MEMKIND_PmemStressSmallSize)
+TEST_F(MemkindPmemLongTimeStress, DISABLED_test_TC_MEMKIND_PmemStressSmallSize)
 {
     void *test = nullptr;
     TimerSysTime timer;
@@ -78,7 +76,7 @@ TEST_F(MemkindPmemLongTimeStress, test_TC_MEMKIND_PmemStressSmallSize)
     } while (timer.getElapsedTime() < STRESS_TIME);
 }
 
-TEST_F(MemkindPmemLongTimeStress, test_TC_MEMKIND_PmemStressLargeSize)
+TEST_F(MemkindPmemLongTimeStress, DISABLED_test_TC_MEMKIND_PmemStressLargeSize)
 {
     void *test = nullptr;
     TimerSysTime timer;
@@ -93,7 +91,8 @@ TEST_F(MemkindPmemLongTimeStress, test_TC_MEMKIND_PmemStressLargeSize)
     } while (timer.getElapsedTime() < STRESS_TIME);
 }
 
-TEST_F(MemkindPmemLongTimeStress, test_TC_MEMKIND_PmemStressSmallAndLargeSize)
+TEST_F(MemkindPmemLongTimeStress,
+       DISABLED_test_TC_MEMKIND_PmemStressSmallAndLargeSize)
 {
     void *test = nullptr;
     size_t i = 0, j = 0;

--- a/test/test.sh
+++ b/test/test.sh
@@ -40,8 +40,6 @@ green=`tput setaf 2`
 yellow=`tput setaf 3`
 default=`tput sgr0`
 
-# Pmem long time stress tests are skipped by default
-SKIPPED_GTESTS=":-MemkindPmemLongTimeStress*"
 
 err=0
 
@@ -68,7 +66,7 @@ OPTIONS
     -x,
         skip tests that are passed as value
     -s,
-        run pmem long time stress tests
+        run disabled test (e.g. pmem long time stress test)
     -h,
         parameter added to display script usage
 EOF
@@ -147,7 +145,7 @@ function execute_gtest()
         fi
     fi
     # Concatenate test command
-    TESTCMD=$(printf "$TESTCMD" "$TEST""$SKIPPED_GTESTS")
+    TESTCMD=$(printf "$TESTCMD" "$TEST""$SKIPPED_GTESTS""$RUN_DISABLED_GTEST")
     # And test prefix if applicable
     if [ "$TEST_PREFIX" != "" ]; then
         TESTCMD=$(printf "$TEST_PREFIX" "$TESTCMD")
@@ -290,8 +288,8 @@ while getopts "T:c:f:l:hdmsx:p:" opt; do
             show_skipped_tests "$OPTARG"
             ;;
         s)
-            SKIPPED_GTESTS="";
-            TEST_FILTER="MemkindPmemLongTimeStress*"
+            echo "Run also disabled tests"
+            RUN_DISABLED_GTEST=" --gtest_also_run_disabled_tests"
             ;;
         h)
             usage;


### PR DESCRIPTION
- disable long time test from default configuration
- change pmem kind used in long test to be limited by the capacity of the file system mounted
- modify test.sh script 

It is still possible to run disable test with passing flag "--gtest_also_run_disabled_tests" when calling gtest binary (e.g. all_tests).

Advantage of this solution is most common call used locally to check pmem functionality:
./all_tests --gtest_filter=*Pmem*
don't call longterm test by default which takes 3 days to finish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/130)
<!-- Reviewable:end -->
