### PR TITLE
FALLOC_FL_PUNCH_HOLE check

### DIFF
--- a/README
+++ b/README
@@ -176,6 +176,10 @@ and pay particular attention to the use of the procfs files:
     /proc/sys/vm/nr_overcommit_hugepages
 for enabling the kernel's huge page pool.
 
+To use the file-backed kind of memory (PMEM), please be sure that
+filesystem which is used for PMEM kind supports FALLOC_FL_PUNCH_HOLE flag:
+    http://man7.org/linux/man-pages/man2/fallocate.2.html
+
 SETTING LOGGING MECHANISM
 --------------------
 In memkind library logging mechanism could be enabled by setting MEMKIND_DEBUG

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -99,7 +99,9 @@ bool pmem_extent_dalloc(extent_hooks_t *extent_hooks,
     // if madvise fail, it means that addr isn't mapped shared (doesn't come from pmem)
     // and it should be unmapped to avoid space exhaustion when calling large number of
     // operations like memkind_create_pmem and memkind_destroy_kind
-    if (madvise(addr, size, MADV_REMOVE) == -1) {
+    // EOPNOTSUPP is returned in case of filesystem doesn't support FALLOC_FL_PUNCH_HOLE
+    errno = 0;
+    if (madvise(addr, size, MADV_REMOVE) != 0 && errno != EOPNOTSUPP) {
         if (munmap(addr, size) == -1) {
             log_err("munmap failed!");
         }


### PR DESCRIPTION
- update pmem kind requirements
- check for filesystem which support FALLOC_FL_PUNCH_HOLE, if not EOPNOTSUPP is returned

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/131)
<!-- Reviewable:end -->
