### PR TITLE
Update travis configuration with new Clang compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,18 +58,18 @@ matrix:
       before_install:
         - eval "${MATRIX_EVAL}"
 
-    - name: "Clang 6.0"
+    - name: "Clang 7"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-trusty-7
           packages:
             - g++-4.8
-            - clang-6.0
+            - clang-7
             - libnuma-dev
       env:
-        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0 && JEMALLOC_CC=gcc-4.8 && JEMALLOC_CXX=g++-4.8"
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7 && JEMALLOC_CC=gcc-4.8 && JEMALLOC_CXX=g++-4.8"
       install:
       script:
         - CXX=$JEMALLOC_CXX CC=$JEMALLOC_CC LDFLAGS="-lrt -Wl,--no-as-needed" ./build_jemalloc.sh 


### PR DESCRIPTION
Clang binary and libraries have been renamed from 7.0 to 7. ( see https://releases.llvm.org/7.0.0/tools/clang/docs/ReleaseNotes.html ) - same for LLVM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/134)
<!-- Reviewable:end -->
