### PR TITLE
Update memkind_malloc_usable_size regarding TBB

### DIFF
--- a/man/memkind.3
+++ b/man/memkind.3
@@ -222,6 +222,13 @@ function provides the same semantics as
 .BR malloc_usable_size(3),
 but operates on specified
 .I kind.
+
+.BR Note:
+.BR memkind_malloc_usable_size ()
+is not supported by TBB heap manager described in
+.B ENVIRONMENT
+section.
+
 .PP
 .BR memkind_free ()
 causes the allocated memory referenced by

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -157,6 +157,12 @@ void tbb_pool_free(struct memkind *kind, void *ptr)
     }
 }
 
+static size_t tbb_pool_usable_size(struct memkind *kind, void *ptr)
+{
+    log_err("memkind_malloc_usable_size() is not supported by TBB.");
+    return 0;
+}
+
 static int tbb_destroy(struct memkind* kind)
 {
     bool pool_destroy_ret = pool_destroy(kind->priv);
@@ -198,4 +204,5 @@ void tbb_initialize(struct memkind *kind)
     kind->ops->realloc = tbb_pool_realloc;
     kind->ops->free = tbb_pool_free;
     kind->ops->finalize = tbb_destroy;
+    kind->ops->malloc_usable_size = tbb_pool_usable_size;
 }


### PR DESCRIPTION
- Currently Threading Building Blocks does not provide any API to
support memkind_malloc_usable_size functionality

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/142)
<!-- Reviewable:end -->
