### PR TITLE
Fix missing newlines in examples.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Pawel Kochanek <pawel.b.kochanek@intel.com>
 Katarzyna Wasiuta <katarzyna.wasiuta@intel.com>
 Krzysztof Filipek <krzysztof.filipek@intel.com>
 Michal Biesek <michal.biesek@intel.com>
+Adam Borowski <adam.borowski@intel.com>

--- a/examples/pmem_alignment.c
+++ b/examples/pmem_alignment.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,11 +47,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
     }
 
     fprintf(stdout,
-            "The memory has been successfully allocated using memkind alignment.");
+            "The memory has been successfully allocated using memkind alignment.\n");
 
     return 0;
 }

--- a/examples/pmem_and_default_kind.c
+++ b/examples/pmem_and_default_kind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,11 +52,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     ptr_default = (char *)memkind_malloc(MEMKIND_DEFAULT, size);
     if (!ptr_default) {
         perror("memkind_malloc()");
-        fprintf(stderr, "Unable allocate 512 bytes in standard memory");
+        fprintf(stderr, "Unable allocate 512 bytes in standard memory\n");
         return errno ? -errno : 1;
     }
 
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     ptr_pmem = (char *)memkind_malloc(pmem_kind, HEAP_LIMIT_SIMULATE);
     if (!ptr_pmem) {
         perror("memkind_malloc()");
-        fprintf(stderr, "Unable allocate HEAP_LIMIT_SIMULATE in file-backed memory");
+        fprintf(stderr, "Unable allocate HEAP_LIMIT_SIMULATE in file-backed memory\n");
         return errno ? -errno : 1;
     }
     if (errno != 0) {

--- a/examples/pmem_cpp_allocator.cpp
+++ b/examples/pmem_cpp_allocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
     } else if (argc == 2) {
         struct stat st;
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr,"%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr,"%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         }
         pmem_directory = argv[1];

--- a/examples/pmem_free_with_unknown_kind.c
+++ b/examples/pmem_free_with_unknown_kind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,11 +50,11 @@ int main(int argc, char **argv)
     int err = 0;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];

--- a/examples/pmem_kinds.c
+++ b/examples/pmem_kinds.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,11 +50,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    fprintf(stdout, "PMEM kinds have been successfully created and destroyed.");
+    fprintf(stdout, "PMEM kinds have been successfully created and destroyed.\n");
 
     return 0;
 }

--- a/examples/pmem_malloc.c
+++ b/examples/pmem_malloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2018 Intel Corporation
+ * Copyright (c) 2015 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,11 +47,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];

--- a/examples/pmem_malloc_unlimited.c
+++ b/examples/pmem_malloc_unlimited.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,11 +45,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory ", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
     fprintf(stdout,
             "This example shows how to allocate memory with unlimited kind size."
-            "nPMEM kind directory: %s\n",
+            "\nPMEM kind directory: %s\n",
             PMEM_DIR);
 
     /* Create PMEM partition with unlimited size */
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
         return errno ? -errno : 1;
     }
 
-    fprintf(stdout, "Memory was successfully allocated and released.");
+    fprintf(stdout, "Memory was successfully allocated and released.\n");
 
     return 0;
 }

--- a/examples/pmem_multithreads.c
+++ b/examples/pmem_multithreads.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,11 +55,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    fprintf(stdout, "Threads successfully allocated memory in the PMEM kinds.");
+    fprintf(stdout, "Threads successfully allocated memory in the PMEM kinds.\n");
 
     return 0;
 }

--- a/examples/pmem_multithreads_onekind.c
+++ b/examples/pmem_multithreads_onekind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,11 +61,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
         free(args[t]);
     }
 
-    fprintf(stdout, "Threads successfully allocated memory in the PMEM kind.");
+    fprintf(stdout, "Threads successfully allocated memory in the PMEM kind.\n");
 
     return 0;
 }

--- a/examples/pmem_usable_size.c
+++ b/examples/pmem_usable_size.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2018 - 2019 Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,11 +45,11 @@ int main(int argc, char *argv[])
     struct stat st;
 
     if (argc > 2) {
-        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]", argv[0]);
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
         return 1;
     } else if (argc == 2) {
         if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "%s : Invalid path to pmem kind directory", argv[1]);
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         } else {
             PMEM_DIR = argv[1];
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
     }
 
     fprintf(stdout,
-            "The real size of the allocation has been successfully read.");
+            "The real size of the allocation has been successfully read.\n");
 
     return 0;
 }


### PR DESCRIPTION
Many messages in the examples lack a final newline — or even end in ".n".  I'm using the examples for autopkgtests, this makes them visible in public CI, thus it'd be a bit nicer to avoid run-in lines.

### Types of changes
- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)
- [ ] Other

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/154)
<!-- Reviewable:end -->
