### PR TITLE
[WIP]Memkind API: memkind_update_memory_usage_policy

### DIFF
--- a/include/memkind.h
+++ b/include/memkind.h
@@ -385,6 +385,15 @@ void *memkind_realloc(memkind_t kind, void *ptr, size_t size);
 ///
 void memkind_free(memkind_t kind, void *ptr);
 
+/// \brief Update kind memory usage policy
+/// \note STANDARD API
+/// \param kind specified memory kind
+/// \param memkind_mem_usage_policy memory usage policy
+/// \return Memkind operation status, MEMKIND_SUCCESS on success, other values on failure
+///
+int memkind_update_memory_usage_policy(memkind_t kind,
+                                       memkind_mem_usage_policy policy);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -567,6 +567,17 @@ MEMKIND_EXPORT int memkind_check_available(struct memkind *kind)
     return err;
 }
 
+MEMKIND_EXPORT int memkind_update_memory_usage_policy(memkind_t kind,
+                                                      memkind_mem_usage_policy policy)
+{
+    int err = MEMKIND_ERROR_OPERATION_FAILED;
+
+    if (MEMKIND_LIKELY(kind->ops->update_memory_usage_policy)) {
+        err = kind->ops->update_memory_usage_policy(kind, policy);
+    }
+    return err;
+}
+
 MEMKIND_EXPORT size_t memkind_malloc_usable_size(struct memkind *kind,
                                                  void *ptr)
 {


### PR DESCRIPTION
Provide API to change memory utilization strategy. 
This is proposal solution for #58 

### Description
- MEMKIND_MEM_USAGE_POLICY_DEFAULT is default memory policy
- MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE results in less fragmentation
- Current solution will support only PMEM

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/158)
<!-- Reviewable:end -->
