### PR TITLE
Unify memkind_posix_memalign for all kinds

### DIFF
--- a/man/hbwmalloc.3
+++ b/man/hbwmalloc.3
@@ -188,6 +188,14 @@ The requested
 .I alignment
 must be a power of 2 at least as large as
 .IR "sizeof(void*)" .
+If
+.I size
+is 0, then
+.BR hbw_posix_memalign ()
+returns 0, with a
+.I NULL
+returned in
+.IR "memptr" .
 .PP
 .BR hbw_posix_memalign_psize ()
 allocates

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -232,8 +232,10 @@ If
 .I size
 is 0, then
 .BR memkind_posix_memalign ()
-returns
-.IR "NULL" .
+returns 0, with a
+.I NULL
+returned in
+.IR "memptr" .
 .PP
 .BR memkind_malloc_usable_size ()
 function provides the same semantics as

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -580,6 +580,9 @@ MEMKIND_EXPORT int memkind_arena_posix_memalign(struct memkind *kind,
         err = memkind_posix_check_alignment(kind, alignment);
     }
     if (MEMKIND_LIKELY(!err)) {
+        if (MEMKIND_UNLIKELY(size_out_of_bounds(size))) {
+            return 0;
+        }
         /* posix_memalign should not change errno.
            Set it to its previous value after calling jemalloc */
         errno_before = errno;

--- a/src/memkind_default.c
+++ b/src/memkind_default.c
@@ -93,7 +93,8 @@ MEMKIND_EXPORT int memkind_default_posix_memalign(struct memkind *kind,
                                                   void **memptr, size_t alignment, size_t size)
 {
     if(MEMKIND_UNLIKELY(size_out_of_bounds(size))) {
-        return EINVAL;
+        *memptr = NULL;
+        return 0;
     }
     return jemk_posix_memalign(memptr, alignment, size);
 }

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -142,7 +142,10 @@ static int tbb_pool_posix_memalign(struct memkind *kind, void **memptr,
     if(!alignment && (0 != (alignment & (alignment-sizeof(void *))))) return EINVAL;
     //Check if alignment is "a power of 2".
     if(alignment & (alignment-1)) return EINVAL;
-    if(size_out_of_bounds(size)) return ENOMEM;
+    if(size_out_of_bounds(size)) {
+        *memptr = NULL;
+        return 0;
+    }
     void *result = pool_aligned_malloc(kind->priv, size, alignment);
     if (!result) {
         return ENOMEM;

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -868,10 +868,12 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPosixMemalignSizeZero)
 {
     void *test = nullptr;
     size_t alignment = sizeof(void *);
-    int ret;
 
-    ret = memkind_posix_memalign(pmem_kind, &test, alignment, 0);
-    ASSERT_TRUE(ret != 0);
+    errno = 0;
+    int ret = memkind_posix_memalign(pmem_kind, &test, alignment, 0);
+
+    ASSERT_TRUE(errno == 0);
+    ASSERT_TRUE(ret == 0);
     ASSERT_TRUE(test == nullptr);
 }
 

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -285,6 +285,22 @@ TEST_F(NegativeTest, test_TC_MEMKIND_Negative_ErrorMemAlign)
     EXPECT_EQ(errno, 0);
 }
 
+TEST_F(NegativeTest, test_TC_MEMKIND_Negative_DefaultSizeZero)
+{
+    int ret = 0;
+    void *ptr = NULL;
+    int err = 0;
+
+    errno = 0;
+    ret = memkind_posix_memalign(MEMKIND_DEFAULT,
+                                 &ptr,
+                                 16,
+                                 0);
+    EXPECT_EQ(err, ret);
+    EXPECT_EQ(errno, 0);
+    ASSERT_TRUE(ptr == NULL);
+}
+
 TEST_F(NegativeTest, test_TC_MEMKIND_Negative_ErrorAlignment)
 {
     int ret = 0;
@@ -298,6 +314,22 @@ TEST_F(NegativeTest, test_TC_MEMKIND_Negative_ErrorAlignment)
                                  100);
     EXPECT_EQ(err, ret);
     EXPECT_EQ(errno, 0);
+}
+
+TEST_F(NegativeTest, test_TC_MEMKIND_Negative_HBWSizeZero)
+{
+    int ret = 0;
+    void *ptr = NULL;
+    int err = 0;
+
+    errno = 0;
+    ret = memkind_posix_memalign(MEMKIND_HBW,
+                                 &ptr,
+                                 16,
+                                 0);
+    EXPECT_EQ(err, ret);
+    EXPECT_EQ(errno, 0);
+    ASSERT_TRUE(ptr == NULL);
 }
 
 
@@ -393,6 +425,17 @@ TEST_F(NegativeTest, test_TC_MEMKIND_Negative_hbw_posix_memalign_over_size)
     int ret = hbw_posix_memalign(&ptr, 4096, SIZE_MAX);
     EXPECT_TRUE(ptr == NULL);
     EXPECT_EQ(ENOMEM, ret);
+}
+
+TEST_F(NegativeTest, test_TC_MEMKIND_Negative_hbw_posix_memalign_size_zero)
+{
+    void *ptr = NULL;
+    errno = 0;
+
+    int ret = hbw_posix_memalign(&ptr, 4096, 0);
+    EXPECT_TRUE(ptr == NULL);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(0, errno);
 }
 
 TEST_F(NegativeTest, test_TC_MEMKIND_Negative_memkind_posix_memalign_over_size)


### PR DESCRIPTION
When memkind_posix_memalign is called with size 0:
- memkind_posix_memalign set *memptr to NULL
- memkind_posix_memalign return 0
- extend test for cases with *_posix_memalign size 0

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/160)
<!-- Reviewable:end -->
