### PR TITLE
Unify memkind_realloc for all kinds

### DIFF
--- a/man/hbwmalloc.3
+++ b/man/hbwmalloc.3
@@ -123,7 +123,17 @@ the
 function behaves identically to
 .BR hbw_malloc ()
 for the specified size.
-The address
+If
+.I size
+is equal to zero, and
+.I ptr
+is not
+.IR "NULL" ,
+then the call is equivalent to
+.I hbw_free(ptr)
+and
+.I NULL
+is returned. The address
 .IR "ptr" ,
 if not
 .IR "NULL" ,

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -186,7 +186,17 @@ the
 function behaves identically to
 .BR memkind_malloc ()
 for the specified size.
-The address
+If
+.I size
+is equal to zero, and
+.I ptr
+is not
+.IR "NULL" ,
+then the call is equivalent to
+.IR "memkind_free(kind, ptr)"
+and
+.I NULL
+is returned. The address
 .IR "ptr" ,
 if not
 .IR "NULL" ,

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -513,7 +513,7 @@ MEMKIND_EXPORT void *memkind_arena_realloc(struct memkind *kind, void *ptr,
     unsigned int arena;
 
     if (size == 0 && ptr != NULL) {
-        memkind_free(kind, ptr);
+        memkind_arena_free(kind, ptr);
         ptr = NULL;
     } else {
         err = kind->ops->get_arena(kind, &arena, size);

--- a/src/memkind_default.c
+++ b/src/memkind_default.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -102,6 +102,7 @@ MEMKIND_EXPORT void *memkind_default_realloc(struct memkind *kind, void *ptr,
                                              size_t size)
 {
     if(MEMKIND_UNLIKELY(size_out_of_bounds(size))) {
+        jemk_free(ptr);
         return NULL;
     }
     return jemk_realloc(ptr, size);

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 - 2018 Intel Corporation.
+ * Copyright (C) 2017 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -125,7 +125,10 @@ static void *tbb_pool_calloc(struct memkind *kind, size_t num, size_t size)
 
 static void *tbb_pool_realloc(struct memkind *kind, void *ptr, size_t size)
 {
-    if(size_out_of_bounds(size)) return NULL;
+    if (size_out_of_bounds(size)) {
+        pool_free(kind->priv, ptr);
+        return NULL;
+    }
     void *result = pool_realloc(kind->priv, ptr, size);
     if (!result && size)
         errno = ENOMEM;

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 - 2018 Intel Corporation.
+ * Copyright (C) 2015 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -437,6 +437,23 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocSizeMax)
     memkind_free(pmem_kind, test);
 }
 
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocSizeZero)
+{
+    size_t size = 1 * KB;
+    void *test = nullptr;
+    void *new_test = nullptr;
+    const size_t iteration = 100;
+
+    for (unsigned i = 0; i < iteration; ++i) {
+        test = memkind_malloc(pmem_kind, size);
+        ASSERT_TRUE(test != nullptr);
+        errno = 0;
+        new_test = memkind_realloc(pmem_kind, test, 0);
+        ASSERT_TRUE(new_test == nullptr);
+        ASSERT_TRUE(errno == 0);
+    }
+}
+
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocPtrCheck)
 {
     size_t size = 1 * KB;
@@ -620,7 +637,7 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeNullptr)
     timer.start();
     do {
         memkind_free(pmem_kind, nullptr);
-    } while(timer.getElapsedTime() < test_time);
+    } while (timer.getElapsedTime() < test_time);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeNullptrNullKind)
@@ -631,7 +648,45 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeNullptrNullKind)
     timer.start();
     do {
         memkind_free(nullptr, nullptr);
-    } while(timer.getElapsedTime() < test_time);
+    } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocNullptrSizeZero)
+{
+    const double test_time = 5;
+    void *test_nullptr = nullptr;
+    TimerSysTime timer;
+    timer.start();
+    do {
+        errno = 0;
+        //equivalent to memkind_malloc(pmem_kind,0)
+        test_nullptr = memkind_realloc(pmem_kind, nullptr, 0);
+        ASSERT_EQ(test_nullptr, nullptr);
+        ASSERT_EQ(errno, 0);
+    } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_DefaultReallocNullptrSizeZero)
+{
+    const double test_time = 5;
+    void *test_nullptr = nullptr;
+    void *test_ptr_malloc = nullptr;
+    void *test_ptr_realloc = nullptr;
+    TimerSysTime timer;
+    timer.start();
+    do {
+        test_ptr_malloc = memkind_malloc(MEMKIND_DEFAULT, 5 * MB);
+        errno = 0;
+        test_ptr_realloc = memkind_realloc(MEMKIND_DEFAULT, test_ptr_malloc, 0);
+        ASSERT_EQ(test_ptr_realloc, nullptr);
+        ASSERT_EQ(errno, 0);
+
+        errno = 0;
+        //equivalent to memkind_malloc(MEMKIND_DEFAULT,0)
+        test_nullptr = memkind_realloc(MEMKIND_DEFAULT, nullptr, 0);
+        ASSERT_EQ(test_nullptr, nullptr);
+        ASSERT_EQ(errno, 0);
+    } while (timer.getElapsedTime() < test_time);
 }
 
 /*


### PR DESCRIPTION
When memkind_realloc() is called with size 0:
- memory pointed by ptr is freed
- NULL is returned

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/161)
<!-- Reviewable:end -->
