### PR TITLE
Modify heap free call

### DIFF
--- a/include/memkind/internal/heap_manager.h
+++ b/include/memkind/internal/heap_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 - 2018 Intel Corporation.
+ * Copyright (C) 2017 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,4 +27,4 @@
 #include <memkind.h>
 
 void heap_manager_init(struct memkind *kind);
-void heap_manager_free(struct memkind *kind, void *ptr);
+void heap_manager_free(void *ptr);

--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,6 +62,7 @@ int memkind_thread_get_arena(struct memkind *kind, unsigned int *arena,
 int memkind_arena_finalize(struct memkind *kind);
 void memkind_arena_init(struct memkind *kind);
 void memkind_arena_free(struct memkind *kind, void *ptr);
+void memkind_arena_free_with_kind_detect(void *ptr);
 
 #ifdef __cplusplus
 }

--- a/include/memkind/internal/tbb_wrapper.h
+++ b/include/memkind/internal/tbb_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Intel Corporation.
+ * Copyright (C) 2017 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,9 @@ void tbb_initialize(struct memkind *kind);
 
 /* ptr pointer must come from the valid TBB pool allocation */
 void tbb_pool_free(struct memkind *kind, void *ptr);
+
+/* ptr pointer must come from the valid TBB pool allocation */
+void tbb_pool_free_with_kind_detect(void *ptr);
 
 #ifdef __cplusplus
 }

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -266,21 +266,21 @@ If
 is
 .IR "NULL" ,
 no operation is performed.
-The value of
-.B MEMKIND_DEFAULT
-can be given as the
-.I kind
-for all buffers allocated by a kind that leverages the jemalloc
-allocator. In cases where the kind is unknown in the
+In cases where the kind is unknown in the
 context of the call to
 .BR memkind_free ()
 .IR "NULL" ,
 can be given as the
 .I kind
 specified to
-.BR memkind_free ()
-but this will require a look up that can be bypassed by specifying
-a non-zero value.
+.BR memkind_free (),
+but this will require a internal look up for correct kind.
+.BR Note:
+The look up for
+.I kind
+could result in serious performance penalty,
+which can be avoided by specifying a correct
+.IR kind .
 .sp
 .B "KIND MANAGEMENT:"
 .br

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -47,6 +47,7 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .BI "int memkind_arena_finalize(struct memkind " "*kind" );
 .BI "void memkind_arena_init(struct memkind " "*kind" );
 .BI "void memkind_arena_free(struct memkind " "*kind" ", void " "*ptr" );
+.BI "void memkind_arena_free_with_kind_detect(void " "*ptr" );
 .br
 .SH DESCRIPTION
 This header file is a collection of functions can be used to populate
@@ -170,6 +171,12 @@ or
 .BR memkind_arena_realloc ()
 to be made available for future allocations.
 It uses the memkind "get_arena" operation to select the arena.
+.PP
+.BR memkind_arena_free_with_kind_detect ()
+function will look up for kind associated to the allocated memory referenced by
+.I ptr
+and call
+.BR memkind_arena_free ().
 .PP
 .BR get_kind_by_arena ()
 returns pointer to memory kind structure associated with given arena.

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 - 2018 Intel Corporation.
+ * Copyright (C) 2017 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,17 +36,17 @@ pthread_once_t heap_manager_init_once_g = PTHREAD_ONCE_INIT;
 
 struct heap_manager_ops {
     void (*init)(struct memkind *kind);
-    void (*heap_manager_free)(struct memkind *kind, void *ptr);
+    void (*heap_manager_free)(void *ptr);
 };
 
 struct heap_manager_ops arena_heap_manager_g = {
     .init = memkind_arena_init,
-    .heap_manager_free = memkind_arena_free
+    .heap_manager_free = memkind_arena_free_with_kind_detect
 };
 
 struct heap_manager_ops tbb_heap_manager_g = {
     .init = tbb_initialize,
-    .heap_manager_free = tbb_pool_free
+    .heap_manager_free = tbb_pool_free_with_kind_detect
 };
 
 static void set_heap_manager()
@@ -69,7 +69,7 @@ void heap_manager_init(struct memkind *kind)
     get_heap_manager()->init(kind);
 }
 
-void heap_manager_free(struct memkind *kind, void *ptr)
+void heap_manager_free(void *ptr)
 {
-    get_heap_manager()->heap_manager_free(kind, ptr);
+    get_heap_manager()->heap_manager_free(ptr);
 }

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -666,7 +666,7 @@ MEMKIND_EXPORT void memkind_free(struct memkind *kind, void *ptr)
     }
 #endif
     if (!kind) {
-        heap_manager_free(kind, ptr);
+        heap_manager_free(ptr);
     } else {
         pthread_once(&kind->init_once, kind->ops->init_once);
         kind->ops->free(kind, ptr);

--- a/src/memkind_gbtlb.c
+++ b/src/memkind_gbtlb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2017 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,7 +43,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_GBTLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = memkind_default_free,
+    .free = memkind_arena_free,
     .mmap = gbtlb_mmap,
     .check_available = memkind_hugetlb_check_available_2mb,
     .mbind = memkind_default_mbind,
@@ -62,7 +62,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_GBTLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = memkind_default_free,
+    .free = memkind_arena_free,
     .mmap = gbtlb_mmap,
     .check_available = memkind_hugetlb_check_available_2mb,
     .mbind = memkind_default_mbind,
@@ -81,7 +81,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_GBTLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = memkind_default_free,
+    .free = memkind_arena_free,
     .mmap = gbtlb_mmap,
     .check_available = memkind_hugetlb_check_available_2mb,
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_default_get_mmap_flags,
@@ -71,7 +71,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_default_get_mmap_flags,
@@ -89,7 +89,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_HUGETLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_hugetlb_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,
@@ -107,7 +107,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_HUGETLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_hugetlb_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,
@@ -125,7 +125,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_default_get_mmap_flags,
@@ -143,7 +143,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_HUGETLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_hugetlb_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,
@@ -161,7 +161,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_INTERLEAVE_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hbw_check_available,
     .mbind = memkind_default_mbind,
     .madvise = memkind_nohugepage_madvise,

--- a/src/memkind_hugetlb.c
+++ b/src/memkind_hugetlb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HUGETLB_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = memkind_default_free,
+    .free = memkind_arena_free,
     .check_available = memkind_hugetlb_check_available_2mb,
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,
     .get_arena = memkind_thread_get_arena,

--- a/src/memkind_interleave.c
+++ b/src/memkind_interleave.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 - 2018 Intel Corporation.
+ * Copyright (C) 2015 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,7 +34,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_INTERLEAVE_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = memkind_default_free,
+    .free = memkind_arena_free,
     .mbind = memkind_default_mbind,
     .madvise = memkind_nohugepage_madvise,
     .get_mmap_flags = memkind_default_get_mmap_flags,

--- a/src/memkind_regular.c
+++ b/src/memkind_regular.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 - 2018 Intel Corporation.
+ * Copyright (C) 2017 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -91,7 +91,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_REGULAR_OPS = {
     .calloc = memkind_arena_calloc,
     .posix_memalign = memkind_arena_posix_memalign,
     .realloc = memkind_arena_realloc,
-    .free = heap_manager_free,
+    .free = memkind_arena_free,
     .check_available = memkind_regular_check_available,
     .mbind = memkind_default_mbind,
     .get_mmap_flags = memkind_default_get_mmap_flags,

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -151,13 +151,14 @@ static int tbb_pool_posix_memalign(struct memkind *kind, void **memptr,
     return 0;
 }
 
+void tbb_pool_free_with_kind_detect(void *ptr)
+{
+    pool_free(pool_identify(ptr), ptr);
+}
+
 void tbb_pool_free(struct memkind *kind, void *ptr)
 {
-    if(kind) {
-        pool_free(kind->priv, ptr);
-    } else {
-        pool_free(pool_identify(ptr), ptr);
-    }
+    pool_free(kind->priv, ptr);
 }
 
 static size_t tbb_pool_usable_size(struct memkind *kind, void *ptr)


### PR DESCRIPTION
### Description

Detect kind only in case of free without kind.
When passing kind there is no need to check if kind exist so I decide it to divide it to two functions.
Give note about possible performance penalty when calling memkind_free with NULL as kind.
Remove no longer valid information about MEMKIND_DEFAULT_FREE.
Since commit a80579fd79412f857c7b6166264e4b8d21392847 it is needed to pass correctly KIND or pass NULL

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/162)
<!-- Reviewable:end -->
