### PR TITLE
TBB changes and new test suite

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -439,6 +439,7 @@ test/memkind-perf-ext.ts
 test/memkind-perf.ts
 test/memkind-pytests.ts
 test/memkind-slts.ts
+test/memkind_null_kind_test.cpp
 test/memkind_pmem_long_time_tests.cpp
 test/memkind_pmem_tests.cpp
 test/memkind_versioning_tests.cpp

--- a/copying_headers/MANIFEST.freeBSD
+++ b/copying_headers/MANIFEST.freeBSD
@@ -129,6 +129,7 @@ test/huge_page_test.cpp
 test/load_tbbmalloc_symbols.c
 test/locality_test.cpp
 test/main.cpp
+test/memkind_null_kind_test.cpp
 test/memkind_pmem_long_time_tests.cpp
 test/memkind_pmem_tests.cpp
 test/memkind_versioning_tests.cpp

--- a/include/memkind/internal/tbb_wrapper.h
+++ b/include/memkind/internal/tbb_wrapper.h
@@ -30,6 +30,9 @@
 extern "C" {
 #endif
 
+/* dynamically load TBB symbols */
+void load_tbb_symbols(void);
+
 /* ops callbacks are replaced by TBB callbacks. */
 void tbb_initialize(struct memkind *kind);
 

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -511,6 +511,17 @@ exit:
 }
 
 #ifdef __GNUC__
+__attribute__((constructor))
+#endif
+static void memkind_construct(void)
+{
+    const char *env = getenv("MEMKIND_HEAP_MANAGER");
+    if (env && strcmp(env, "TBB") == 0) {
+        load_tbb_symbols();
+    }
+}
+
+#ifdef __GNUC__
 __attribute__((destructor))
 #endif
 static int memkind_finalize(void)

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -82,6 +82,7 @@ test_all_tests_SOURCES = $(fused_gtest) \
                          test/get_arena_test.cpp \
                          test/hbw_allocator_tests.cpp \
                          test/hbw_verify_function_test.cpp \
+                         test/memkind_null_kind_test.cpp \
                          test/memkind_pmem_long_time_tests.cpp \
                          test/memkind_pmem_tests.cpp \
                          test/memkind_versioning_tests.cpp \

--- a/test/memkind_null_kind_test.cpp
+++ b/test/memkind_null_kind_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice(s),
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice(s),
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "memkind.h"
+
+#include "allocator_perf_tool/TimerSysTime.hpp"
+#include "common.h"
+
+class MemkindNullKindTests: public ::testing::Test
+{
+
+protected:
+    void SetUp()
+    {}
+
+    void TearDown()
+    {}
+};
+
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultKindFreeNullPtr)
+{
+    const double test_time = 5;
+
+    TimerSysTime timer;
+    timer.start();
+    do {
+        memkind_free(MEMKIND_DEFAULT, nullptr);
+    } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_NullKindFreeNullPtr)
+{
+    const double test_time = 5;
+
+    TimerSysTime timer;
+    timer.start();
+    do {
+        memkind_free(nullptr, nullptr);
+    } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultRegularKindFreeNullPtr)
+{
+    const size_t size_1 = 1 * KB;
+    const size_t size_2 = 1 * MB;
+    void *ptr_default = nullptr;
+    void *ptr_regular = nullptr;
+    for (unsigned int i = 0; i < MEMKIND_MAX_KIND; ++i) {
+        ptr_default = memkind_malloc(MEMKIND_DEFAULT, size_2);
+        ASSERT_TRUE(nullptr != ptr_default);
+        memkind_free(nullptr, ptr_default);
+        ptr_default = memkind_malloc(MEMKIND_DEFAULT, size_1);
+        ASSERT_TRUE(nullptr != ptr_default);
+        memkind_free(nullptr, ptr_default);
+        ptr_regular = memkind_malloc(MEMKIND_REGULAR, size_2);
+        ASSERT_TRUE(nullptr != ptr_regular);
+        memkind_free(nullptr, ptr_regular);
+        ptr_regular = memkind_malloc(MEMKIND_REGULAR, size_1);
+        ASSERT_TRUE(nullptr != ptr_regular);
+        memkind_free(nullptr, ptr_regular);
+    }
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultReallocNullptrSizeZero)
+{
+    const double test_time = 5;
+    void *test_nullptr = nullptr;
+    void *test_ptr_malloc = nullptr;
+    void *test_ptr_realloc = nullptr;
+    TimerSysTime timer;
+    timer.start();
+    do {
+        test_ptr_malloc = memkind_malloc(MEMKIND_DEFAULT, 5 * MB);
+        errno = 0;
+        test_ptr_realloc = memkind_realloc(MEMKIND_DEFAULT, test_ptr_malloc, 0);
+        ASSERT_EQ(test_ptr_realloc, nullptr);
+        ASSERT_EQ(errno, 0);
+
+        errno = 0;
+        //equivalent to memkind_malloc(MEMKIND_DEFAULT,0)
+        test_nullptr = memkind_realloc(MEMKIND_DEFAULT, nullptr, 0);
+        ASSERT_EQ(test_nullptr, nullptr);
+        ASSERT_EQ(errno, 0);
+    } while (timer.getElapsedTime() < test_time);
+}

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -640,17 +640,6 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeNullptr)
     } while (timer.getElapsedTime() < test_time);
 }
 
-TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeNullptrNullKind)
-{
-    const double test_time = 5;
-
-    TimerSysTime timer;
-    timer.start();
-    do {
-        memkind_free(nullptr, nullptr);
-    } while (timer.getElapsedTime() < test_time);
-}
-
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocNullptrSizeZero)
 {
     const double test_time = 5;
@@ -661,29 +650,6 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocNullptrSizeZero)
         errno = 0;
         //equivalent to memkind_malloc(pmem_kind,0)
         test_nullptr = memkind_realloc(pmem_kind, nullptr, 0);
-        ASSERT_EQ(test_nullptr, nullptr);
-        ASSERT_EQ(errno, 0);
-    } while (timer.getElapsedTime() < test_time);
-}
-
-TEST_F(MemkindPmemTests, test_TC_MEMKIND_DefaultReallocNullptrSizeZero)
-{
-    const double test_time = 5;
-    void *test_nullptr = nullptr;
-    void *test_ptr_malloc = nullptr;
-    void *test_ptr_realloc = nullptr;
-    TimerSysTime timer;
-    timer.start();
-    do {
-        test_ptr_malloc = memkind_malloc(MEMKIND_DEFAULT, 5 * MB);
-        errno = 0;
-        test_ptr_realloc = memkind_realloc(MEMKIND_DEFAULT, test_ptr_malloc, 0);
-        ASSERT_EQ(test_ptr_realloc, nullptr);
-        ASSERT_EQ(errno, 0);
-
-        errno = 0;
-        //equivalent to memkind_malloc(MEMKIND_DEFAULT,0)
-        test_nullptr = memkind_realloc(MEMKIND_DEFAULT, nullptr, 0);
         ASSERT_EQ(test_nullptr, nullptr);
         ASSERT_EQ(errno, 0);
     } while (timer.getElapsedTime() < test_time);


### PR DESCRIPTION
Update controls TBB heap manager

- Move load TBB symbols in memkind constructor method: Before the change, if MEMKIND_HEAP_MANAGER=TBB and memkind_free(NULL,NULL) was called as first method program would crash. Loading TBB symbols was done, when tbb_initialize method was called, which was done only for memkind allocation functions.

- pool_identify_ptr crash, when call with NULL value: add handling NULL value on memkind layer

Move tests, which are related to functionality with detecting kind to separate file

### Types of changes

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [x] All newly added files have proprietary license (if necessary)
- [x] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/164)
<!-- Reviewable:end -->
