### PR TITLE
Fix rpm build config and generating VERSION file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: trusty
 sudo: required
 language: cpp
 cache: ccache
+git:
+  depth: false
 matrix:
   fast_finish: true
   include:

--- a/Makefile.am
+++ b/Makefile.am
@@ -413,8 +413,7 @@ memkind-$(VERSION).spec:
 	$(MAKE) version="$(VERSION)" -f memkind.spec.mk $@
 
 rpm: dist
-	$(MAKE) version="$(VERSION)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" \
-		-f memkind.spec.mk $@
+	$(MAKE) version="$(VERSION)" -f memkind.spec.mk $@
 
 all: static_lib
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright (C) 2014-2017 Intel Corporation.
+#  Copyright (C) 2014 - 2019 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -27,18 +27,24 @@ set -e
 
 # If the VERSION file does not exist, then create it based on git
 # describe or if not in a git repo just set VERSION to 0.0.0.
+# Determine VERSION scheme, based on git:
+# -if HEAD is tag annotated - it is official release e.g. setting VERSION to "1.9.0"
+# -if HEAD is not tag annotated - it is snapshot e.g. setting VERSION to "1.8.0+dev19+g1c93b2d"
+
 if [ ! -f VERSION ]; then
     if [ -f .git/config ]; then
-        sha=$(git describe --long --always | awk -F- '{print $(NF)}')
+        sha=$(git describe --long | awk -F- '{print $(NF)}')
         release=$(git describe --long | awk -F- '{print $(NF-1)}')
         version=$(git describe --long | sed -e "s|\(.*\)-$release-$sha|\1|" -e "s|-|+|g" -e "s|^v||")
-        if [ "$release" == "" ]; then
-            version=${sha}
+        if [ ${release} != "0" ]; then
+            echo "WARNING: No annotated tag refering to this commit was found, setting version to development build " 2>&1
+            version=${version}+dev${release}+${sha}
         else
-            version=${version}+dev${release}-${sha}
+            echo "Annotated tag refering to this commit was found, setting version as an official release" 2>&1
+            version=${version}
         fi
     else
-        echo "WARNING:  VERSION file does not exist and working directory is not a git repository, setting verison to 0.0.0" 2>&1
+        echo "WARNING: VERSION file does not exist and working directory is not a git repository, setting version to 0.0.0" 2>&1
         version=0.0.0
     fi
     echo $version > VERSION


### PR DESCRIPTION
Fix make rpm

### Description
This change is related to build system and generating VERSION file:

- revert changes from 23073f6a702d3512db726941982203c5d790b361:
Workaround for Travis issue with cloning repository to a maximum depth 50 commits is performed in travis config file
- determine VERSION scheme if current commit is mark as tag annotated it is official release, in other cases it is snapshot ( this is done to avoid situation, like in #143)
- passing CPPFLAGS and LDFLAGS would override jemalloc build configuration

 Ref #153 

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/167)
<!-- Reviewable:end -->
