### PR TITLE
Heap manager realloc

### DIFF
--- a/include/memkind/internal/heap_manager.h
+++ b/include/memkind/internal/heap_manager.h
@@ -28,3 +28,4 @@
 
 void heap_manager_init(struct memkind *kind);
 void heap_manager_free(void *ptr);
+void *heap_manager_realloc(void *ptr, size_t size);

--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -55,6 +55,7 @@ void *memkind_arena_pmem_calloc(struct memkind *kind, size_t num, size_t size);
 int memkind_arena_posix_memalign(struct memkind *kind, void **memptr,
                                  size_t alignment, size_t size);
 void *memkind_arena_realloc(struct memkind *kind, void *ptr, size_t size);
+void *memkind_arena_realloc_with_kind_detect(void *pt, size_t size);
 int memkind_bijective_get_arena(struct memkind *kind, unsigned int *arena,
                                 size_t size);
 int memkind_thread_get_arena(struct memkind *kind, unsigned int *arena,

--- a/include/memkind/internal/tbb_wrapper.h
+++ b/include/memkind/internal/tbb_wrapper.h
@@ -42,6 +42,9 @@ void tbb_pool_free(struct memkind *kind, void *ptr);
 /* ptr pointer must come from the valid TBB pool allocation */
 void tbb_pool_free_with_kind_detect(void *ptr);
 
+/* ptr pointer must come from the valid TBB pool allocation */
+void *tbb_pool_realloc_with_kind_detect(void *ptr, size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -213,6 +213,37 @@ as specified to the call to
 Otherwise, if
 .I memkind_free(kind, ptr)
 was called before, undefined behavior occurs.
+In cases where the kind is unknown in the
+context of the call to
+.BR memkind_realloc ()
+.IR "NULL" ,
+can be given as the
+.I kind
+specified to
+.BR memkind_realloc (),
+but this will require a internal look up for correct kind.
+.BR Note:
+The look up for
+.I kind
+could result in serious performance penalty,
+which can be avoided by specifying a correct
+.IR kind .
+If
+.I kind
+is
+.I NULL
+and
+.I ptr
+is
+.IR "NULL" ,
+then
+.BR memkind_realloc ()
+returns
+.I NULL
+and sets
+.I errno
+to
+.BR EINVAL .
 .PP
 .BR memkind_posix_memalign ()
 allocates

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -41,6 +41,7 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .BI "void *memkind_arena_pmem_calloc(struct memkind " "*kind" ", size_t " "num" ", size_t " "size" );
 .BI "int memkind_arena_posix_memalign(struct memkind " "*kind" ", void " "**memptr" ", size_t " "alignment" ", size_t " "size" );
 .BI "void *memkind_arena_realloc(struct memkind " "*kind" ", void " "*ptr" ", size_t " "size" );
+.BI "void *memkind_arena_realloc_with_kind_detect(void " "*ptr" ", size_t " "size" );
 .BI "int memkind_thread_get_arena(struct memkind " "*kind" ", unsigned int " "*arena" ", size_t " "size" );
 .BI "int memkind_bijective_get_arena(struct memkind " "*kind" ", unsigned int " "*arena" ", size_t " "size" );
 .BI "struct memkind *get_kind_by_arena(unsigned " "arena_ind" );
@@ -142,6 +143,14 @@ through the jemalloc's
 .BR mallocx ()
 interface.  It uses the memkind "get_arena" operation to select the
 arena.
+.PP
+.BR memkind_arena_realloc_with_kind_detect ()
+function will look up for kind associated to the allocated memory referenced by
+.I ptr
+and call (depending on kind value)
+.BR memkind_arena_realloc ()
+or
+.BR memkind_default_realloc ().
 .PP
 .BR memkind_thread_get_arena ()
 retrieves the

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -37,16 +37,19 @@ pthread_once_t heap_manager_init_once_g = PTHREAD_ONCE_INIT;
 struct heap_manager_ops {
     void (*init)(struct memkind *kind);
     void (*heap_manager_free)(void *ptr);
+    void *(*heap_manager_realloc)(void *ptr, size_t size);
 };
 
 struct heap_manager_ops arena_heap_manager_g = {
     .init = memkind_arena_init,
-    .heap_manager_free = memkind_arena_free_with_kind_detect
+    .heap_manager_free = memkind_arena_free_with_kind_detect,
+    .heap_manager_realloc = memkind_arena_realloc_with_kind_detect
 };
 
 struct heap_manager_ops tbb_heap_manager_g = {
     .init = tbb_initialize,
-    .heap_manager_free = tbb_pool_free_with_kind_detect
+    .heap_manager_free = tbb_pool_free_with_kind_detect,
+    .heap_manager_realloc = tbb_pool_realloc_with_kind_detect
 };
 
 static void set_heap_manager()
@@ -72,4 +75,9 @@ void heap_manager_init(struct memkind *kind)
 void heap_manager_free(void *ptr)
 {
     get_heap_manager()->heap_manager_free(ptr);
+}
+
+void *heap_manager_realloc(void *ptr, size_t size)
+{
+    return get_heap_manager()->heap_manager_realloc(ptr, size);
 }

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -650,15 +650,18 @@ MEMKIND_EXPORT void *memkind_realloc(struct memkind *kind, void *ptr,
 {
     void *result;
 
-    pthread_once(&kind->init_once, kind->ops->init_once);
-
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_realloc_pre) {
         memkind_realloc_pre(&kind, &ptr, &size);
     }
 #endif
 
-    result = kind->ops->realloc(kind, ptr, size);
+    if (!kind) {
+        result = heap_manager_realloc(ptr, size);
+    } else {
+        pthread_once(&kind->init_once, kind->ops->init_once);
+        result = kind->ops->realloc(kind, ptr, size);
+    }
 
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_realloc_post) {

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -446,6 +446,19 @@ static inline int memkind_lookup_arena(void *ptr, unsigned int *arena)
     return 0;
 }
 
+static struct memkind *get_kind_by_ptr(void *ptr)
+{
+    struct memkind *kind = NULL;
+    if (ptr != NULL) {
+        unsigned arena;
+        int err = memkind_lookup_arena(ptr, &arena);
+        if (MEMKIND_LIKELY(!err)) {
+            kind = get_kind_by_arena(arena);
+        }
+    }
+    return kind;
+}
+
 static inline int get_tcache_flag(unsigned partition, size_t size)
 {
 
@@ -500,14 +513,8 @@ MEMKIND_EXPORT void memkind_arena_free(struct memkind *kind, void *ptr)
 
 MEMKIND_EXPORT void memkind_arena_free_with_kind_detect(void *ptr)
 {
-    struct memkind *kind = NULL;
-    if (ptr != NULL) {
-        unsigned int arena;
-        int err = memkind_lookup_arena(ptr, &arena);
-        if (MEMKIND_LIKELY(!err)) {
-            kind = get_kind_by_arena(arena);
-        }
-    }
+    struct memkind *kind = get_kind_by_ptr(ptr);
+
     memkind_arena_free(kind, ptr);
 }
 
@@ -533,6 +540,21 @@ MEMKIND_EXPORT void *memkind_arena_realloc(struct memkind *kind, void *ptr,
         }
     }
     return ptr;
+}
+
+MEMKIND_EXPORT void *memkind_arena_realloc_with_kind_detect(void *ptr,
+                                                            size_t size)
+{
+    if (!ptr) {
+        errno = EINVAL;
+        return NULL;
+    }
+    struct memkind *kind = get_kind_by_ptr(ptr);
+    if (!kind) {
+        return memkind_default_realloc(kind, ptr, size);
+    } else {
+        return memkind_arena_realloc(kind, ptr, size);
+    }
 }
 
 // TODO: function is workaround for PR#1302 in jemalloc upstream

--- a/test/memkind_null_kind_test.cpp
+++ b/test/memkind_null_kind_test.cpp
@@ -69,21 +69,21 @@ TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultRegularKindFreeNullPtr)
     void *ptr_regular = nullptr;
     for (unsigned int i = 0; i < MEMKIND_MAX_KIND; ++i) {
         ptr_default = memkind_malloc(MEMKIND_DEFAULT, size_2);
-        ASSERT_TRUE(nullptr != ptr_default);
+        ASSERT_NE(ptr_default, nullptr);
         memkind_free(nullptr, ptr_default);
         ptr_default = memkind_malloc(MEMKIND_DEFAULT, size_1);
-        ASSERT_TRUE(nullptr != ptr_default);
+        ASSERT_NE(ptr_default, nullptr);
         memkind_free(nullptr, ptr_default);
         ptr_regular = memkind_malloc(MEMKIND_REGULAR, size_2);
-        ASSERT_TRUE(nullptr != ptr_regular);
+        ASSERT_NE(ptr_regular, nullptr);
         memkind_free(nullptr, ptr_regular);
         ptr_regular = memkind_malloc(MEMKIND_REGULAR, size_1);
-        ASSERT_TRUE(nullptr != ptr_regular);
+        ASSERT_NE(ptr_regular, nullptr);
         memkind_free(nullptr, ptr_regular);
     }
 }
 
-TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultReallocNullptrSizeZero)
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultKindReallocNullptrSizeZero)
 {
     const double test_time = 5;
     void *test_nullptr = nullptr;
@@ -104,4 +104,115 @@ TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultReallocNullptrSizeZero)
         ASSERT_EQ(test_nullptr, nullptr);
         ASSERT_EQ(errno, 0);
     } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindNullKindTests,
+       test_TC_MEMKIND_DefaultKindReallocNullKindSizeZeroImplicitFree)
+{
+    const double test_time = 5;
+    size_t size = 1 * KB;
+    void *test_ptr_malloc = nullptr;
+    void *test_ptr_realloc = nullptr;
+    TimerSysTime timer;
+    timer.start();
+    do {
+        errno = 0;
+        test_ptr_malloc = memkind_malloc(MEMKIND_DEFAULT, size);
+        ASSERT_NE(test_ptr_malloc, nullptr);
+        ASSERT_EQ(errno, 0);
+
+        errno = 0;
+        test_ptr_realloc = memkind_realloc(nullptr, test_ptr_malloc, 0);
+        ASSERT_EQ(test_ptr_realloc, nullptr);
+        ASSERT_EQ(errno, 0);
+    } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultKindReallocNullKindSizeMax)
+{
+    size_t size = 1 * KB;
+    void *test_ptr_malloc = nullptr;
+    void *test_ptr_realloc = nullptr;
+
+    test_ptr_malloc = memkind_malloc(MEMKIND_DEFAULT, size);
+    ASSERT_NE(test_ptr_malloc, nullptr);
+
+    errno = 0;
+    test_ptr_realloc = memkind_realloc(nullptr, test_ptr_malloc, SIZE_MAX);
+    ASSERT_EQ(test_ptr_realloc, nullptr);
+    ASSERT_EQ(errno, ENOMEM);
+
+    memkind_free(nullptr, test_ptr_malloc);
+}
+
+TEST_F(MemkindNullKindTests,
+       test_TC_MEMKIND_DefaultReallocIncreaseSizeNullKindVariant)
+{
+    size_t size = 1 * KB;
+    char *test1 = nullptr;
+    char *test2 = nullptr;
+    const char val[] = "test_TC_MEMKIND_DefaultReallocIncreaseSizeNullKindVariant";
+    int status;
+
+    test1 = (char *)memkind_malloc(MEMKIND_DEFAULT, size);
+    ASSERT_NE(test1, nullptr);
+
+    sprintf(test1, "%s", val);
+
+    size *= 2;
+    test2 = (char *)memkind_realloc(nullptr, test1, size);
+    ASSERT_NE(test2, nullptr);
+    status = memcmp(val, test2, sizeof(val));
+    ASSERT_EQ(status, 0);
+
+    memkind_free(MEMKIND_DEFAULT, test2);
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_ReallocNullptrNullKind)
+{
+    size_t size = 1 * KB;
+
+    errno = 0;
+    void *test = memkind_realloc(nullptr, nullptr, size);
+    ASSERT_EQ(test, nullptr);
+    ASSERT_EQ(errno, EINVAL);
+}
+
+TEST_F(MemkindNullKindTests,
+       test_TC_MEMKIND_DefaultReallocDecreaseSizeNullKindVariant)
+{
+    size_t size = 1 * KB;
+    char *test1 = nullptr;
+    char *test2 = nullptr;
+    const char val[] = "test_TC_MEMKIND_DefaultReallocDecreaseSizeNullKindVariant";
+    int status;
+
+    test1 = (char *)memkind_malloc(MEMKIND_DEFAULT, size);
+    ASSERT_NE(test1, nullptr);
+
+    sprintf(test1, "%s", val);
+
+    size = 4;
+    test2 = (char *)memkind_realloc(nullptr, test1, size);
+    ASSERT_NE(test2, nullptr);
+    status = memcmp(val, test2, size);
+    ASSERT_EQ(status, 0);
+
+    memkind_free(MEMKIND_DEFAULT, test2);
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_ReallocNullptrNullKindSizeMax)
+{
+    errno = 0;
+    void *test = memkind_realloc(nullptr, nullptr, SIZE_MAX);
+    ASSERT_EQ(test, nullptr);
+    ASSERT_EQ(errno, EINVAL);
+}
+
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_ReallocNullptrNullKindSizeZero)
+{
+    errno = 0;
+    void *test = memkind_realloc(nullptr, nullptr, 0);
+    ASSERT_EQ(test, nullptr);
+    ASSERT_EQ(errno, EINVAL);
 }

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -522,6 +522,28 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocIncreaseSize)
     memkind_free(pmem_kind, test2);
 }
 
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocIncreaseSizeNullKindVariant)
+{
+    size_t size = 1 * KB;
+    char *test1 = nullptr;
+    char *test2 = nullptr;
+    const char val[] = "test_TC_MEMKIND_PmemReallocIncreaseSizeNullKindVariant";
+    int status;
+
+    test1 = (char *)memkind_malloc(pmem_kind, size);
+    ASSERT_TRUE(test1 != nullptr);
+
+    sprintf(test1, "%s", val);
+
+    size *= 2;
+    test2 = (char *)memkind_realloc(nullptr, test1, size);
+    ASSERT_TRUE(test2 != nullptr);
+    status = memcmp(val, test2, sizeof(val));
+    ASSERT_TRUE(status == 0);
+
+    memkind_free(pmem_kind, test2);
+}
+
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocDecreaseSize)
 {
     size_t size = 1 * KB;
@@ -537,6 +559,28 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocDecreaseSize)
 
     size = 4;
     test2 = (char *)memkind_realloc(pmem_kind, test1, size);
+    ASSERT_TRUE(test2 != nullptr);
+    status = memcmp(val, test2, size);
+    ASSERT_TRUE(status == 0);
+
+    memkind_free(pmem_kind, test2);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocDecreaseSizeNullKindVariant)
+{
+    size_t size = 1 * KB;
+    char *test1 = nullptr;
+    char *test2 = nullptr;
+    const char val[] = "test_TC_MEMKIND_PmemReallocDecreaseSizeNullKindVariant";
+    int status;
+
+    test1 = (char *)memkind_malloc(pmem_kind, size);
+    ASSERT_TRUE(test1 != nullptr);
+
+    sprintf(test1, "%s", val);
+
+    size = 4;
+    test2 = (char *)memkind_realloc(nullptr, test1, size);
     ASSERT_TRUE(test2 != nullptr);
     status = memcmp(val, test2, size);
     ASSERT_TRUE(status == 0);
@@ -650,6 +694,28 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocNullptrSizeZero)
         errno = 0;
         //equivalent to memkind_malloc(pmem_kind,0)
         test_nullptr = memkind_realloc(pmem_kind, nullptr, 0);
+        ASSERT_EQ(test_nullptr, nullptr);
+        ASSERT_EQ(errno, 0);
+    } while (timer.getElapsedTime() < test_time);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocNullKindSizeZero)
+{
+    const double test_time = 5;
+    void *test_ptr_malloc = nullptr;
+    void *test_nullptr = nullptr;
+    size_t size = 1 * KB;
+
+    TimerSysTime timer;
+    timer.start();
+    do {
+        errno = 0;
+        test_ptr_malloc = memkind_malloc(pmem_kind, size);
+        ASSERT_NE(test_ptr_malloc, nullptr);
+        ASSERT_EQ(errno, 0);
+
+        errno = 0;
+        test_nullptr = memkind_realloc(nullptr, test_ptr_malloc, 0);
         ASSERT_EQ(test_nullptr, nullptr);
         ASSERT_EQ(errno, 0);
     } while (timer.getElapsedTime() < test_time);


### PR DESCRIPTION
- provide functionality in the same way as heap_manager free for realloc
operation
- return NULL and set errno to EINVAL in case of
memkind_realloc(NULL,NULL,x)
- add missing fix for pool_identify_ptr(NULL) from which should be added
in 9f2ea1be0662f79f103a1be9e3b64511750daa78

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/168)
<!-- Reviewable:end -->
