### PR TITLE
get_defrag_hint update

### DIFF
--- a/include/memkind/internal/memkind_default.h
+++ b/include/memkind/internal/memkind_default.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,7 +63,7 @@ int memkind_nohugepage_madvise(struct memkind *kind, void *addr, size_t size);
 int memkind_posix_check_alignment(struct memkind *kind, size_t alignment);
 void memkind_default_init_once(void);
 size_t memkind_default_malloc_usable_size(struct memkind *kind, void *ptr);
-
+int memkind_default_get_defrag_hint(void *ptr, int *bin_util, int *run_util);
 static inline bool size_out_of_bounds(size_t size)
 {
     return !size;

--- a/include/memkind/internal/memkind_private.h
+++ b/include/memkind/internal/memkind_private.h
@@ -71,9 +71,7 @@ extern "C" {
 #define jemk_free                   JE_SYMBOL(free)
 #define jemk_dallocx                JE_SYMBOL(dallocx)
 #define jemk_malloc_usable_size     JE_SYMBOL(malloc_usable_size)
-
-/// \note EXPERIMENTAL API
-int je_get_defrag_hint(void *ptr, int *bin_util, int *run_util);
+#define jemk_get_defrag_hint        JE_SYMBOL(get_defrag_hint)
 
 enum memkind_const_private {
     MEMKIND_NAME_LENGTH_PRIV = 64

--- a/jemalloc/configure.ac
+++ b/jemalloc/configure.ac
@@ -821,7 +821,7 @@ AC_ARG_WITH([export],
 fi]
 )
 
-public_syms="aligned_alloc calloc dallocx free mallctl mallctlbymib mallctlnametomib malloc malloc_conf malloc_message malloc_stats_print malloc_usable_size mallocx nallocx posix_memalign rallocx realloc sallocx sdallocx xallocx"
+public_syms="aligned_alloc calloc dallocx free mallctl mallctlbymib mallctlnametomib malloc malloc_conf malloc_message malloc_stats_print malloc_usable_size mallocx nallocx posix_memalign rallocx realloc sallocx sdallocx xallocx get_defrag_hint"
 dnl Check for additional platform-specific public API functions.
 AC_CHECK_FUNC([memalign],
 	      [AC_DEFINE([JEMALLOC_OVERRIDE_MEMALIGN], [ ])

--- a/jemalloc/include/jemalloc/jemalloc_protos.h.in
+++ b/jemalloc/include/jemalloc/jemalloc_protos.h.in
@@ -40,6 +40,7 @@ JEMALLOC_EXPORT void JEMALLOC_NOTHROW	@je_@sdallocx(void *ptr, size_t size,
     int flags);
 JEMALLOC_EXPORT size_t JEMALLOC_NOTHROW	@je_@nallocx(size_t size, int flags)
     JEMALLOC_ATTR(pure);
+JEMALLOC_EXPORT int JEMALLOC_NOTHROW @je_@get_defrag_hint(void* ptr, int *bin_util, int *run_util);
 
 JEMALLOC_EXPORT int JEMALLOC_NOTHROW	@je_@mallctl(const char *name,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen);

--- a/jemalloc/src/jemalloc.c
+++ b/jemalloc/src/jemalloc.c
@@ -3157,7 +3157,7 @@ jemalloc_postfork_child(void) {
  * returns the bin utilization and run utilization both in fixed point 16:16.
  * If the application decides to re-allocate it should use MALLOCX_TCACHE_NONE when doing so. */
 JEMALLOC_EXPORT int JEMALLOC_NOTHROW
-get_defrag_hint(void* ptr, int *bin_util, int *run_util) {
+je_get_defrag_hint(void* ptr, int *bin_util, int *run_util) {
 	assert(ptr != NULL);
 	return iget_defrag_hint(TSDN_NULL, ptr, bin_util, run_util);
 }

--- a/man/memkind_default.3
+++ b/man/memkind_default.3
@@ -69,6 +69,8 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .br
 .BI "void memkind_default_init_once(void);"
 .br
+.BI "int memkind_default_get_defrag_hint(void " "*ptr" ", int " "*bin_util" ", int " "*run_util" );
+.br
 .BI "bool size_out_of_bounds(size_t " "size" );
 .br
 .SH DESCRIPTION
@@ -214,6 +216,13 @@ This function copies body of the bitmask structure into passed pointer.
 .PP
 .BR memkind_default_init_once ()
 initializes heap manager.
+.PP
+.BR memkind_default_get_defrag_hint ()
+is a direct call through the jemalloc's
+.BR get_defrag_hint ().
+If
+.BR get_defrag_hint ()
+is not supported function returns -1.
 .PP
 .BR size_out_of_bounds ()
 returns true if given size is out of bounds, otherwise will return false.

--- a/src/memkind_default.c
+++ b/src/memkind_default.c
@@ -120,6 +120,18 @@ MEMKIND_EXPORT size_t memkind_default_malloc_usable_size(struct memkind *kind,
     return jemk_malloc_usable_size(ptr);
 }
 
+MEMKIND_EXPORT int memkind_default_get_defrag_hint(void *ptr, int *bin_util,
+                                                   int *run_util)
+{
+#ifdef JEMALLOC_FRAG_HINT
+    return jemk_get_defrag_hint(ptr,bin_util,run_util);
+#else
+    log_err("jemk_get_defrag_hint() is not available in jemalloc.");
+    return -1;
+#endif
+}
+
+
 MEMKIND_EXPORT void *memkind_default_mmap(struct memkind *kind, void *addr,
                                           size_t size)
 {


### PR DESCRIPTION
- provide interace in memkind_default as wrapper for jemalloc function
- get_defrag_hint will use JE_PREFIX
- provide conditional check to don't fail build with jemalloc >5.1

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/170)
<!-- Reviewable:end -->
