### PR TITLE
[RFC] extend API with memkind_detect_kind function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ autom4te.cache/
 /test/memkind_allocated
 /test/new_kind
 /test/perf_tool
+/test/pmem_detect_kind
 /test/pmem_kinds
 /test/pmem_malloc
 /test/pmem_malloc_unlimited
@@ -99,6 +100,7 @@ autom4te.cache/
 /examples/new_kind
 /examples/numakind_test
 /examples/numakind_macro.h
+/examples/pmem_detect_kind
 /examples/pmem_kinds
 /examples/pmem_malloc
 /examples/pmem_malloc_unlimited

--- a/MANIFEST
+++ b/MANIFEST
@@ -31,6 +31,7 @@ examples/memkind_decorator_debug.c
 examples/pmem_alignment.c
 examples/pmem_and_default_kind.c
 examples/pmem_cpp_allocator.cpp
+examples/pmem_detect_kind.c
 examples/pmem_free_with_unknown_kind.c
 examples/pmem_kinds.c
 examples/pmem_malloc.c
@@ -440,6 +441,7 @@ test/memkind-perf-ext.ts
 test/memkind-perf.ts
 test/memkind-pytests.ts
 test/memkind-slts.ts
+test/memkind_detect_kind_tests.cpp
 test/memkind_null_kind_test.cpp
 test/memkind_pmem_long_time_tests.cpp
 test/memkind_pmem_tests.cpp

--- a/copying_headers/MANIFEST.freeBSD
+++ b/copying_headers/MANIFEST.freeBSD
@@ -129,6 +129,7 @@ test/huge_page_test.cpp
 test/load_tbbmalloc_symbols.c
 test/locality_test.cpp
 test/main.cpp
+test/memkind_detect_kind_tests.cpp
 test/memkind_null_kind_test.cpp
 test/memkind_pmem_long_time_tests.cpp
 test/memkind_pmem_tests.cpp

--- a/copying_headers/MANIFEST.freeBSD3
+++ b/copying_headers/MANIFEST.freeBSD3
@@ -1,6 +1,7 @@
 examples/pmem_alignment.c
 examples/pmem_and_default_kind
 examples/pmem_cpp_allocator.cpp
+examples/pmem_detect_kind.c
 examples/pmem_free_with_unknown_kind.c
 examples/pmem_kinds.c
 examples/pmem_malloc.c

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -29,6 +29,7 @@ noinst_PROGRAMS += examples/autohbw_candidates \
                    examples/hello_memkind_debug \
                    examples/pmem_alignment \
                    examples/pmem_and_default_kind \
+                   examples/pmem_detect_kind \
                    examples/pmem_free_with_unknown_kind \
                    examples/pmem_kinds \
                    examples/pmem_malloc \
@@ -49,6 +50,7 @@ examples_hello_memkind_LDADD = libmemkind.la
 examples_hello_memkind_debug_LDADD = libmemkind.la
 examples_pmem_alignment_LDADD = libmemkind.la
 examples_pmem_and_default_kind_LDADD = libmemkind.la
+examples_pmem_detect_kind_LDADD = libmemkind.la
 examples_pmem_free_with_unknown_kind_LDADD = libmemkind.la
 examples_pmem_kinds_LDADD = libmemkind.la
 examples_pmem_malloc_LDADD = libmemkind.la
@@ -69,6 +71,7 @@ examples_hello_memkind_SOURCES = examples/hello_memkind_example.c
 examples_hello_memkind_debug_SOURCES = examples/hello_memkind_example.c examples/memkind_decorator_debug.c
 examples_pmem_alignment_SOURCES = examples/pmem_alignment.c
 examples_pmem_and_default_kind_SOURCES = examples/pmem_and_default_kind.c
+examples_pmem_detect_kind_SOURCES = examples/pmem_detect_kind.c
 examples_pmem_free_with_unknown_kind_SOURCES = examples/pmem_free_with_unknown_kind.c
 examples_pmem_kinds_SOURCES = examples/pmem_kinds.c
 examples_pmem_malloc_SOURCES = examples/pmem_malloc.c

--- a/examples/README
+++ b/examples/README
@@ -44,6 +44,10 @@ This example shows how to use multithreading with one main pmem kind.
 
 This example shows how to allocate in standard memory and file-backed memory (pmem kind).
 
+### pmem_detect_kind.c
+
+This example shows how to distinguish allocation from different kinds using detect kind function.
+
 ### pmem_free_with_unknown_kind.c
 
 This example shows how to allocate in standard memory and file-backed memory (pmem kind)

--- a/examples/pmem_detect_kind.c
+++ b/examples/pmem_detect_kind.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memkind.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+static char *PMEM_DIR = "/tmp/";
+
+#define MALLOC_SIZE 512U
+#define REALLOC_SIZE 2048U
+#define ALLOC_LIMIT  1000U
+
+static void *alloc_buffer[ALLOC_LIMIT];
+
+static int allocate_pmem_and_default_kind(struct memkind *pmem_kind)
+{
+    unsigned i;
+    for(i = 0; i < ALLOC_LIMIT; i++) {
+        if (i%2)
+            alloc_buffer[i] = memkind_malloc(pmem_kind, MALLOC_SIZE);
+        else
+            alloc_buffer[i] = memkind_malloc(MEMKIND_DEFAULT, MALLOC_SIZE);
+
+        if (!alloc_buffer[i]) {
+            perror("memkind_malloc()");
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int realloc_using_get_kind_only_on_pmem()
+{
+    unsigned i;
+    for(i = 0; i < ALLOC_LIMIT; i++) {
+        if (memkind_detect_kind(alloc_buffer[i]) != MEMKIND_DEFAULT) {
+            void *temp = memkind_realloc(NULL, alloc_buffer[i], REALLOC_SIZE);
+            if (!temp) {
+                perror("memkind_realloc()");
+                return 1;
+            }
+            alloc_buffer[i] = temp;
+        }
+    }
+
+    return 0;
+}
+
+
+static int verify_allocation_size(struct memkind *pmem_kind, size_t pmem_size)
+{
+    unsigned i;
+    for(i = 0; i < ALLOC_LIMIT; i++) {
+        void *val = alloc_buffer[i];
+        if (i%2) {
+            if (memkind_malloc_usable_size(pmem_kind, val) != pmem_size ) {
+                return 1;
+            }
+        } else {
+            if (memkind_malloc_usable_size(MEMKIND_DEFAULT, val) != MALLOC_SIZE) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+
+    struct memkind *pmem_kind = NULL;
+    int err = 0;
+    struct stat st;
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [pmem_kind_dir_path]\n", argv[0]);
+        return 1;
+    } else if (argc == 2) {
+        if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
+            fprintf(stderr, "%s : Invalid path to pmem kind directory\n", argv[1]);
+            return 1;
+        } else {
+            PMEM_DIR = argv[1];
+        }
+    }
+
+    fprintf(stdout,
+            "This example shows how to distinguish allocation from different kinds using detect kind function"
+            "\nPMEM kind directory: %s\n",
+            PMEM_DIR);
+
+
+    err = memkind_create_pmem(PMEM_DIR, 0, &pmem_kind);
+    if (err) {
+        perror("memkind_create_pmem()");
+        fprintf(stderr, "Unable to create pmem partition err=%d errno=%d\n", err,
+                errno);
+        return errno ? -errno : 1;
+    }
+
+    fprintf(stdout, "Allocate to PMEM and DEFAULT kind.\n");
+
+    if (allocate_pmem_and_default_kind(pmem_kind)) {
+        perror("allocate_pmem_and_default_kind()");
+        return 1;
+    }
+
+    if (verify_allocation_size(pmem_kind, MALLOC_SIZE)) {
+        perror("verify_allocation_size() before resize");
+        return 1;
+    }
+
+    fprintf(stdout,
+            "Reallocate memory only on PMEM kind using memkind_detect_kind().\n");
+
+    if (realloc_using_get_kind_only_on_pmem()) {
+        perror("realloc_using_get_kind_only_on_pmem()");
+        return 1;
+    }
+
+    if (verify_allocation_size(pmem_kind, REALLOC_SIZE)) {
+        perror("verify_allocation_size() after resize");
+        return 1;
+    }
+
+    err = memkind_destroy_kind(pmem_kind);
+    if (err) {
+        perror("memkind_destroy_kind()");
+        fprintf(stderr, "Unable to destroy pmem partition\n");
+        return errno ? -errno : 1;
+    }
+
+    fprintf(stdout, "Memory from PMEM kind was successfully reallocated.\n");
+
+    return 0;
+}

--- a/include/memkind.h
+++ b/include/memkind.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 - 2018 Intel Corporation.
+ * Copyright (C) 2014 - 2019 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -182,6 +182,14 @@ int memkind_create_kind(memkind_memtype_t memtype_flags,
 ///
 int memkind_destroy_kind(memkind_t kind);
 
+///
+/// \brief Get kind associated with allocated memory refernced by ptr
+/// \warning STANDARD API
+/// \note This function has non-trivial performance overhead
+/// \param ptr pointer to the allocated memory
+/// \return Kind associated with allocated memory, NULL on failure
+///
+memkind_t memkind_detect_kind(void *ptr);
 
 #include "memkind_deprecated.h"
 
@@ -284,6 +292,7 @@ size_t memkind_malloc_usable_size(memkind_t kind, void *ptr);
 ///
 void *memkind_calloc(memkind_t kind, size_t num, size_t size);
 
+///
 /// \brief Allocates size bytes of the specified kind and places the address of the allocated memory
 ///        in *memptr. The address of the allocated memory will be a multiple of alignment,
 ///        which must be a power of two and a multiple of sizeof(void *)

--- a/include/memkind/internal/heap_manager.h
+++ b/include/memkind/internal/heap_manager.h
@@ -29,3 +29,4 @@
 void heap_manager_init(struct memkind *kind);
 void heap_manager_free(void *ptr);
 void *heap_manager_realloc(void *ptr, size_t size);
+struct memkind *heap_manager_detect_kind(void *ptr);

--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -44,7 +44,7 @@ extern "C" {
  */
 
 struct memkind *get_kind_by_arena(unsigned arena_ind);
-
+struct memkind *memkind_arena_detect_kind(void *ptr);
 int memkind_arena_create(struct memkind *kind, struct memkind_ops *ops,
                          const char *name);
 int memkind_arena_create_map(struct memkind *kind, extent_hooks_t *hooks);

--- a/include/memkind/internal/tbb_wrapper.h
+++ b/include/memkind/internal/tbb_wrapper.h
@@ -42,6 +42,9 @@ void tbb_pool_free_with_kind_detect(void *ptr);
 /* ptr pointer must come from the valid TBB pool allocation */
 void *tbb_pool_realloc_with_kind_detect(void *ptr, size_t size);
 
+/* ptr pointer must come from the valid TBB pool allocation */
+struct memkind *tbb_detect_kind(void *ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -63,6 +63,8 @@ This header expose STANDARD and EXPERIMENTAL API. API Standards are described be
 .BI "void memkind_free(memkind_t " "kind" ", void " "*ptr" );
 .br
 .BI "size_t memkind_malloc_usable_size(memkind_t " "kind" ", void " "*ptr" );
+.br
+.BI "memkind_t memkind_detect_kind(void " "*ptr" );
 .sp
 .B "KIND MANAGEMENT:"
 .br
@@ -273,13 +275,33 @@ function provides the same semantics as
 .BR malloc_usable_size (3),
 but operates on specified
 .IR "kind" .
-
+.br
 .BR Note:
 .BR memkind_malloc_usable_size ()
 is not supported by TBB heap manager described in
 .B ENVIRONMENT
 section.
-
+.PP
+.BR memkind_detect_kind ()
+returns the kind associated with allocated memory referenced by
+.IR ptr .
+This pointer
+must have been returned by a previous call to
+.BR memkind_malloc (),
+.BR memkind_calloc (),
+.BR memkind_realloc ()
+or
+.BR memkind_posix_memalign ().
+If
+.I ptr
+is
+.IR "NULL" ,
+then
+.BR memkind_detect_kind ()
+returns
+.IR "NULL" .
+.BR Note:
+This function has non-trivial performance overhead.
 .PP
 .BR memkind_free ()
 causes the allocated memory referenced by

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -45,6 +45,7 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .BI "int memkind_thread_get_arena(struct memkind " "*kind" ", unsigned int " "*arena" ", size_t " "size" );
 .BI "int memkind_bijective_get_arena(struct memkind " "*kind" ", unsigned int " "*arena" ", size_t " "size" );
 .BI "struct memkind *get_kind_by_arena(unsigned " "arena_ind" );
+.BI "struct memkind *memkind_arena_detect_kind(void " "*ptr" );
 .BI "int memkind_arena_finalize(struct memkind " "*kind" );
 .BI "void memkind_arena_init(struct memkind " "*kind" );
 .BI "void memkind_arena_free(struct memkind " "*kind" ", void " "*ptr" );
@@ -186,6 +187,10 @@ function will look up for kind associated to the allocated memory referenced by
 .I ptr
 and call
 .BR memkind_arena_free ().
+.PP
+.BR memkind_arena_detect_kind ()
+returns pointer to memory kind structure associated with given allocated memory referenced by
+.IR ptr .
 .PP
 .BR get_kind_by_arena ()
 returns pointer to memory kind structure associated with given arena.

--- a/memkind.spec.mk
+++ b/memkind.spec.mk
@@ -204,6 +204,7 @@ ${memkind_test_dir}/pmem_malloc_unlimited
 ${memkind_test_dir}/pmem_usable_size
 ${memkind_test_dir}/pmem_alignment
 ${memkind_test_dir}/pmem_and_default_kind
+$(memkind_test_dir)/pmem_detect_kind
 ${memkind_test_dir}/pmem_multithreads
 ${memkind_test_dir}/pmem_multithreads_onekind
 $(memkind_test_dir)/pmem_free_with_unknown_kind

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -38,18 +38,21 @@ struct heap_manager_ops {
     void (*init)(struct memkind *kind);
     void (*heap_manager_free)(void *ptr);
     void *(*heap_manager_realloc)(void *ptr, size_t size);
+    struct memkind *(*heap_manager_detect_kind)(void *ptr);
 };
 
 struct heap_manager_ops arena_heap_manager_g = {
     .init = memkind_arena_init,
     .heap_manager_free = memkind_arena_free_with_kind_detect,
-    .heap_manager_realloc = memkind_arena_realloc_with_kind_detect
+    .heap_manager_realloc = memkind_arena_realloc_with_kind_detect,
+    .heap_manager_detect_kind = memkind_arena_detect_kind
 };
 
 struct heap_manager_ops tbb_heap_manager_g = {
     .init = tbb_initialize,
     .heap_manager_free = tbb_pool_free_with_kind_detect,
-    .heap_manager_realloc = tbb_pool_realloc_with_kind_detect
+    .heap_manager_realloc = tbb_pool_realloc_with_kind_detect,
+    .heap_manager_detect_kind = tbb_detect_kind
 };
 
 static void set_heap_manager()
@@ -80,4 +83,9 @@ void heap_manager_free(void *ptr)
 void *heap_manager_realloc(void *ptr, size_t size)
 {
     return get_heap_manager()->heap_manager_realloc(ptr, size);
+}
+
+struct memkind *heap_manager_detect_kind(void *ptr)
+{
+    return get_heap_manager()->heap_manager_detect_kind(ptr);
 }

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -342,6 +342,11 @@ MEMKIND_EXPORT int memkind_destroy_kind(memkind_t kind)
     return err;
 }
 
+MEMKIND_EXPORT memkind_t memkind_detect_kind(void *ptr)
+{
+    return heap_manager_detect_kind(ptr);
+}
+
 /* Declare weak symbols for allocator decorators */
 extern void memkind_malloc_pre(struct memkind **,
                                size_t *) __attribute__((weak));

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -446,17 +446,22 @@ static inline int memkind_lookup_arena(void *ptr, unsigned int *arena)
     return 0;
 }
 
-static struct memkind *get_kind_by_ptr(void *ptr)
+MEMKIND_EXPORT struct memkind *memkind_arena_detect_kind(void *ptr)
 {
-    struct memkind *kind = NULL;
-    if (ptr != NULL) {
-        unsigned arena;
-        int err = memkind_lookup_arena(ptr, &arena);
-        if (MEMKIND_LIKELY(!err)) {
-            kind = get_kind_by_arena(arena);
-        }
+    if (!ptr) {
+        return NULL;
     }
-    return kind;
+    struct memkind *kind = NULL;
+    unsigned arena;
+    int err = memkind_lookup_arena(ptr, &arena);
+    if (MEMKIND_LIKELY(!err)) {
+        kind = get_kind_by_arena(arena);
+    }
+
+    /* if no kind was associated with arena it means that allocation doesn't come from
+       jemk_*allocx API - it is jemk_*alloc API (MEMKIND_DEFAULT) */
+
+    return (kind) ? kind : MEMKIND_DEFAULT;
 }
 
 static inline int get_tcache_flag(unsigned partition, size_t size)
@@ -504,7 +509,7 @@ MEMKIND_EXPORT void *memkind_arena_malloc(struct memkind *kind, size_t size)
 
 MEMKIND_EXPORT void memkind_arena_free(struct memkind *kind, void *ptr)
 {
-    if (!kind) {
+    if (kind == MEMKIND_DEFAULT) {
         jemk_free(ptr);
     } else if (ptr != NULL) {
         jemk_dallocx(ptr, get_tcache_flag(kind->partition, 0));
@@ -513,7 +518,7 @@ MEMKIND_EXPORT void memkind_arena_free(struct memkind *kind, void *ptr)
 
 MEMKIND_EXPORT void memkind_arena_free_with_kind_detect(void *ptr)
 {
-    struct memkind *kind = get_kind_by_ptr(ptr);
+    struct memkind *kind = memkind_arena_detect_kind(ptr);
 
     memkind_arena_free(kind, ptr);
 }
@@ -549,8 +554,8 @@ MEMKIND_EXPORT void *memkind_arena_realloc_with_kind_detect(void *ptr,
         errno = EINVAL;
         return NULL;
     }
-    struct memkind *kind = get_kind_by_ptr(ptr);
-    if (!kind) {
+    struct memkind *kind = memkind_arena_detect_kind(ptr);
+    if (kind == MEMKIND_DEFAULT) {
         return memkind_default_realloc(kind, ptr, size);
     } else {
         return memkind_arena_realloc(kind, ptr, size);

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -149,6 +149,24 @@ void *tbb_pool_realloc_with_kind_detect(void *ptr, size_t size)
     return tbb_pool_common_realloc(pool_identify(ptr), ptr, size);
 }
 
+struct memkind *tbb_detect_kind(void *ptr)
+{
+    if (!ptr) {
+        return NULL;
+    }
+    struct memkind *kind = NULL;
+    unsigned i;
+    void *pool = pool_identify(ptr);
+    for (i = 0; i < MEMKIND_MAX_KIND; ++i) {
+        int err = memkind_get_kind_by_partition(i, &kind);
+        if (!err && kind->priv == pool) {
+            break;
+        }
+    }
+
+    return kind;
+}
+
 static int tbb_pool_posix_memalign(struct memkind *kind, void **memptr,
                                    size_t alignment, size_t size)
 {

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -82,6 +82,7 @@ test_all_tests_SOURCES = $(fused_gtest) \
                          test/get_arena_test.cpp \
                          test/hbw_allocator_tests.cpp \
                          test/hbw_verify_function_test.cpp \
+                         test/memkind_detect_kind_tests.cpp \
                          test/memkind_null_kind_test.cpp \
                          test/memkind_pmem_long_time_tests.cpp \
                          test/memkind_pmem_tests.cpp \
@@ -229,6 +230,7 @@ check_PROGRAMS += test/autohbw_candidates \
                   test/hello_memkind_debug \
                   test/pmem_alignment \
                   test/pmem_and_default_kind \
+                  test/pmem_detect_kind \
                   test/pmem_free_with_unknown_kind \
                   test/pmem_kinds \
                   test/pmem_malloc \
@@ -249,6 +251,7 @@ test_hello_memkind_LDADD = libmemkind.la
 test_hello_memkind_debug_LDADD = libmemkind.la
 test_pmem_alignment_LDADD = libmemkind.la
 test_pmem_and_default_kind_LDADD = libmemkind.la
+test_pmem_detect_kind_LDADD = libmemkind.la
 test_pmem_free_with_unknown_kind_LDADD = libmemkind.la
 test_pmem_kinds_LDADD = libmemkind.la
 test_pmem_malloc_LDADD = libmemkind.la
@@ -268,6 +271,7 @@ test_hello_memkind_SOURCES = examples/hello_memkind_example.c
 test_hello_memkind_debug_SOURCES = examples/hello_memkind_example.c examples/memkind_decorator_debug.c
 test_pmem_alignment_SOURCES = examples/pmem_alignment.c
 test_pmem_and_default_kind_SOURCES = examples/pmem_and_default_kind.c
+test_pmem_detect_kind_SOURCES = examples/pmem_detect_kind.c
 test_pmem_free_with_unknown_kind_SOURCES = examples/pmem_free_with_unknown_kind.c
 test_pmem_kinds_SOURCES = examples/pmem_kinds.c
 test_pmem_malloc_SOURCES = examples/pmem_malloc.c

--- a/test/memkind_detect_kind_tests.cpp
+++ b/test/memkind_detect_kind_tests.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice(s),
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice(s),
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memkind.h>
+#include "common.h"
+
+extern const char *PMEM_DIR;
+
+class MemkindDetectKindTests: public ::testing::Test
+{
+
+protected:
+    void SetUp()
+    {}
+
+    void TearDown()
+    {}
+};
+
+TEST_F(MemkindDetectKindTests, test_TC_MEMKIND_DetectKindNullPtr)
+{
+    struct memkind *temp_kind = memkind_detect_kind(nullptr);
+    ASSERT_EQ(nullptr, temp_kind);
+}
+
+TEST_F(MemkindDetectKindTests, test_TC_MEMKIND_DetectKindPmemKind)
+{
+    memkind_t pmem_kind_temp = nullptr;
+    int err = memkind_create_pmem(PMEM_DIR, 0, &pmem_kind_temp);
+    ASSERT_EQ(0, err);
+    ASSERT_NE(nullptr, pmem_kind_temp);
+
+    void *ptr = memkind_malloc(pmem_kind_temp, 512);
+    ASSERT_NE(nullptr, ptr);
+
+    struct memkind *temp_kind = memkind_detect_kind(ptr);
+    ASSERT_EQ(pmem_kind_temp, temp_kind);
+
+    memkind_free(pmem_kind_temp, ptr);
+
+    err = memkind_destroy_kind(pmem_kind_temp);
+    ASSERT_EQ(0, err);
+}
+
+TEST_F(MemkindDetectKindTests, test_TC_MEMKIND_DetectKindRegularKind)
+{
+    void *ptr = memkind_malloc(MEMKIND_REGULAR, 512);
+    ASSERT_NE(nullptr, ptr);
+    struct memkind *temp_kind = memkind_detect_kind(ptr);
+    ASSERT_EQ(MEMKIND_REGULAR, temp_kind);
+    memkind_free(MEMKIND_REGULAR, ptr);
+}
+
+TEST_F(MemkindDetectKindTests, test_TC_MEMKIND_DetectDefaultSmallSizeKind)
+{
+    void *ptr = memkind_malloc(MEMKIND_DEFAULT, 512);
+    ASSERT_NE(nullptr, ptr);
+    struct memkind *temp_kind = memkind_detect_kind(ptr);
+    ASSERT_EQ(MEMKIND_DEFAULT, temp_kind);
+    memkind_free(MEMKIND_DEFAULT, ptr);
+}
+
+TEST_F(MemkindDetectKindTests, test_TC_MEMKIND_DetectDefaultBigSizeKind)
+{
+    void *ptr = memkind_malloc(MEMKIND_DEFAULT, 8 * MB);
+    ASSERT_NE(nullptr, ptr);
+    struct memkind *temp_kind = memkind_detect_kind(ptr);
+    ASSERT_EQ(MEMKIND_DEFAULT, temp_kind);
+    memkind_free(MEMKIND_DEFAULT, ptr);
+}
+
+TEST_F(MemkindDetectKindTests, test_TC_MEMKIND_DetectKindMixKind)
+{
+    const size_t alloc_size = 512;
+    memkind_t pmem_kind_temp_1 = nullptr;
+    memkind_t pmem_kind_temp_2 = nullptr;
+    struct memkind *temp_kind = nullptr;
+    void *ptr_pmem_1 = nullptr;
+    void *ptr_pmem_2 = nullptr;
+    void *ptr_regular = nullptr;
+    void *ptr_default = nullptr;
+
+    int err = memkind_create_pmem(PMEM_DIR, 0, &pmem_kind_temp_1);
+    ASSERT_EQ(0, err);
+    ASSERT_NE(nullptr, pmem_kind_temp_1);
+
+    err = memkind_create_pmem(PMEM_DIR, MEMKIND_PMEM_MIN_SIZE, &pmem_kind_temp_2);
+    ASSERT_EQ(0, err);
+    ASSERT_NE(nullptr, pmem_kind_temp_2);
+
+    ptr_pmem_1 = memkind_malloc(pmem_kind_temp_1, alloc_size);
+    ASSERT_NE(nullptr, ptr_pmem_1);
+
+    ptr_pmem_2 = memkind_malloc(pmem_kind_temp_2, alloc_size);
+    ASSERT_NE(nullptr, ptr_pmem_2);
+
+    ptr_default = memkind_malloc(MEMKIND_DEFAULT, alloc_size);
+    ASSERT_NE(nullptr, ptr_default);
+
+    ptr_regular = memkind_malloc(MEMKIND_REGULAR, alloc_size);
+    ASSERT_NE(nullptr, ptr_regular);
+
+    temp_kind = memkind_detect_kind(ptr_default);
+    ASSERT_EQ(MEMKIND_DEFAULT, temp_kind);
+
+    temp_kind = memkind_detect_kind(ptr_pmem_1);
+    ASSERT_EQ(pmem_kind_temp_1, temp_kind);
+
+    temp_kind = memkind_detect_kind(ptr_regular);
+    ASSERT_EQ(MEMKIND_REGULAR, temp_kind);
+
+    temp_kind = memkind_detect_kind(ptr_pmem_2);
+    ASSERT_EQ(pmem_kind_temp_2, temp_kind);
+
+    memkind_free(pmem_kind_temp_2, ptr_pmem_2);
+    memkind_free(pmem_kind_temp_1, ptr_pmem_1);
+    memkind_free(MEMKIND_DEFAULT, ptr_default);
+    memkind_free(MEMKIND_REGULAR, ptr_regular);
+
+    err = memkind_destroy_kind(pmem_kind_temp_2);
+    ASSERT_EQ(0, err);
+    err = memkind_destroy_kind(pmem_kind_temp_1);
+    ASSERT_EQ(0, err);
+}


### PR DESCRIPTION
- mark memkind_detect_kind as NON-STANDARD API
- expose function to detect kind associated from memory
- add MEMKIND_LIKELY to detect arena operation

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [x] All newly added files have proprietary license (if necessary)
- [x] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/172)
<!-- Reviewable:end -->
