### PR TITLE
Remove -disable-stats option

### DIFF
--- a/README
+++ b/README
@@ -99,7 +99,7 @@ Alternatively you can follow this step-by-step instruction:
     mkdir obj
     cd obj
     ../configure --enable-autogen --with-jemalloc-prefix=jemk_ --without-export \
-                 --disable-stats --disable-fill --disable-initial-exec-tls \
+                 --disable-fill --disable-initial-exec-tls \
                  --with-malloc-conf="narenas:256,lg_tcache_max:12"
     make
     cd ../..

--- a/build_jemalloc.sh
+++ b/build_jemalloc.sh
@@ -29,7 +29,7 @@ test -e configure || autoconf
 test -e obj || mkdir obj
 cd obj
 ../configure --enable-autogen --with-jemalloc-prefix=$JE_PREFIX --without-export \
-             --disable-stats --disable-fill --disable-initial-exec-tls \
+             --disable-fill --disable-initial-exec-tls \
              $EXTRA_CONF --with-malloc-conf="narenas:256,lg_tcache_max:12"
 
 make -j`nproc`


### PR DESCRIPTION
- defrag_hint functionality depends of stats collected by jemalloc

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/174)
<!-- Reviewable:end -->
