### PR TITLE
Fix building for opensuse

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright (C) 2016 Intel Corporation.
+#  Copyright (C) 2016 - 2019 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -44,5 +44,5 @@ if [ ! -f ./Makefile ]; then
 fi
 
 #use V=1 for full cmdlines of build
-make all -j $MAKEOPTS
-make checkprogs -j $MAKEOPTS
+make all -j`nproc`
+make checkprogs -j`nproc`

--- a/memkind.spec.mk
+++ b/memkind.spec.mk
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014 - 2018 Intel Corporation.
+#  Copyright (C) 2014 - 2019 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -55,8 +55,10 @@ BuildRequires: numactl-devel
 
 Prefix: %{_prefix}
 Prefix: %{_unitdir}
+%if %{undefined suse_version}
 Obsoletes: memkind
 Provides: memkind libmemkind0
+%endif
 
 %define namespace memkind
 
@@ -94,8 +96,10 @@ Feedback on design or implementation is greatly appreciated.
 Summary: Memkind User Extensible Heap Manager development lib and tools
 Group: Development/Libraries
 Requires: %{name} = %{version}-%{release}
+%if %{undefined suse_version}
 Obsoletes: memkind-devel
 Provides: memkind-devel
+%endif
 
 %description devel
 Install header files and development aids to link memkind library into


### PR DESCRIPTION
### Description
 - Fix failing in OpenSUSE "https://
build.opensuse.org/:"/.build.packages/RPMS/x86_64/....rpm has an
nversioned self-provide.Remove it, self-provides are done automatically"
 - Remove unused $MAKEOPTS (see 4ec2fc7)
 - Fix failing in CentOS_7 with unsufficent memory during build - using
nproc

### Types of changes

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/186)
<!-- Reviewable:end -->
