### PR TITLE
Provide passing NULL as kind in memkind_malloc_usable_size

### DIFF
--- a/include/memkind/internal/heap_manager.h
+++ b/include/memkind/internal/heap_manager.h
@@ -28,5 +28,6 @@
 
 void heap_manager_init(struct memkind *kind);
 void heap_manager_free(void *ptr);
+size_t heap_manager_malloc_usable_size(void *ptr);
 void *heap_manager_realloc(void *ptr, size_t size);
 struct memkind *heap_manager_detect_kind(void *ptr);

--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -64,6 +64,7 @@ int memkind_arena_finalize(struct memkind *kind);
 void memkind_arena_init(struct memkind *kind);
 void memkind_arena_free(struct memkind *kind, void *ptr);
 void memkind_arena_free_with_kind_detect(void *ptr);
+size_t memkind_arena_malloc_usable_size(void *ptr);
 int memkind_arena_update_memory_usage_policy(struct memkind *kind,
                                              memkind_mem_usage_policy policy);
 #ifdef __cplusplus

--- a/include/memkind/internal/tbb_wrapper.h
+++ b/include/memkind/internal/tbb_wrapper.h
@@ -43,6 +43,9 @@ void tbb_pool_free_with_kind_detect(void *ptr);
 void *tbb_pool_realloc_with_kind_detect(void *ptr, size_t size);
 
 /* ptr pointer must come from the valid TBB pool allocation */
+size_t tbb_pool_malloc_usable_size_with_kind_detect(void *ptr);
+
+/* ptr pointer must come from the valid TBB pool allocation */
 struct memkind *tbb_detect_kind(void *ptr);
 
 #ifdef __cplusplus

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -293,6 +293,15 @@ but operates on specified
 .IR "kind" .
 .br
 .BR Note:
+In cases where the kind is unknown in the
+context of the call to
+.BR memkind_malloc_usable_size ()
+.IR "NULL" ,
+can be given as the
+.I kind
+specified to
+.BR memkind_malloc_usable_size (),
+but this could require a internal look up for correct kind.
 .BR memkind_malloc_usable_size ()
 is supported by TBB heap manager described in
 .B ENVIRONMENT

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -50,6 +50,7 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .BI "void memkind_arena_init(struct memkind " "*kind" );
 .BI "void memkind_arena_free(struct memkind " "*kind" ", void " "*ptr" );
 .BI "void memkind_arena_free_with_kind_detect(void " "*ptr" );
+.BI "size_t memkind_arena_malloc_usable_size(void " "*ptr" );
 .BI "int memkind_arena_update_memory_usage_policy(struct memkind " "*kind" ", memkind_mem_usage_policy " "policy" );
 .br
 .SH DESCRIPTION
@@ -195,6 +196,9 @@ returns pointer to memory kind structure associated with given allocated memory 
 .PP
 .BR get_kind_by_arena ()
 returns pointer to memory kind structure associated with given arena.
+.PP
+.BR memkind_arena_malloc_usable_size ()
+is an implementation of the memkind "usable_size" operation for memory kinds that use jemalloc.
 .PP
 .BR memkind_arena_finalize ()
 is an implementation of the memkind "finalize" operation for memory kinds that

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -36,6 +36,7 @@ pthread_once_t heap_manager_init_once_g = PTHREAD_ONCE_INIT;
 
 struct heap_manager_ops {
     void (*init)(struct memkind *kind);
+    size_t (*heap_manager_malloc_usable_size)(void *ptr);
     void (*heap_manager_free)(void *ptr);
     void *(*heap_manager_realloc)(void *ptr, size_t size);
     struct memkind *(*heap_manager_detect_kind)(void *ptr);
@@ -43,6 +44,7 @@ struct heap_manager_ops {
 
 struct heap_manager_ops arena_heap_manager_g = {
     .init = memkind_arena_init,
+    .heap_manager_malloc_usable_size = memkind_arena_malloc_usable_size,
     .heap_manager_free = memkind_arena_free_with_kind_detect,
     .heap_manager_realloc = memkind_arena_realloc_with_kind_detect,
     .heap_manager_detect_kind = memkind_arena_detect_kind
@@ -50,6 +52,7 @@ struct heap_manager_ops arena_heap_manager_g = {
 
 struct heap_manager_ops tbb_heap_manager_g = {
     .init = tbb_initialize,
+    .heap_manager_malloc_usable_size = tbb_pool_malloc_usable_size_with_kind_detect,
     .heap_manager_free = tbb_pool_free_with_kind_detect,
     .heap_manager_realloc = tbb_pool_realloc_with_kind_detect,
     .heap_manager_detect_kind = tbb_detect_kind
@@ -73,6 +76,11 @@ static inline struct heap_manager_ops *get_heap_manager()
 void heap_manager_init(struct memkind *kind)
 {
     get_heap_manager()->init(kind);
+}
+
+size_t heap_manager_malloc_usable_size(void *ptr)
+{
+    return get_heap_manager()->heap_manager_malloc_usable_size(ptr);
 }
 
 void heap_manager_free(void *ptr)

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -570,12 +570,11 @@ MEMKIND_EXPORT int memkind_check_available(struct memkind *kind)
 MEMKIND_EXPORT size_t memkind_malloc_usable_size(struct memkind *kind,
                                                  void *ptr)
 {
-    size_t size = 0;
-
-    if (MEMKIND_LIKELY(kind->ops->malloc_usable_size)) {
-        size = kind->ops->malloc_usable_size(kind, ptr);
+    if (!kind) {
+        return heap_manager_malloc_usable_size(ptr);
+    } else {
+        return kind->ops->malloc_usable_size(kind, ptr);
     }
-    return size;
 }
 
 MEMKIND_EXPORT void *memkind_malloc(struct memkind *kind, size_t size)

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -525,6 +525,11 @@ MEMKIND_EXPORT void memkind_arena_free_with_kind_detect(void *ptr)
     memkind_arena_free(kind, ptr);
 }
 
+MEMKIND_EXPORT size_t memkind_arena_malloc_usable_size(void *ptr)
+{
+    return memkind_default_malloc_usable_size(NULL, ptr);
+}
+
 MEMKIND_EXPORT void *memkind_arena_realloc(struct memkind *kind, void *ptr,
                                            size_t size)
 {

--- a/src/memkind_gbtlb.c
+++ b/src/memkind_gbtlb.c
@@ -52,6 +52,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_GBTLB_OPS = {
     .get_mbind_nodemask = memkind_hbw_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_gbtlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -71,6 +72,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_GBTLB_OPS = {
     .get_mbind_nodemask = memkind_hbw_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_preferred_gbtlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -87,6 +89,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_GBTLB_OPS = {
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_gbtlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -61,6 +61,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_OPS = {
     .get_mbind_nodemask = memkind_hbw_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -79,6 +80,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_OPS = {
     .get_mbind_nodemask = memkind_hbw_all_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_all_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -97,6 +99,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_HUGETLB_OPS = {
     .get_mbind_nodemask = memkind_hbw_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_hugetlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -115,6 +118,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_HUGETLB_OPS = {
     .get_mbind_nodemask = memkind_hbw_all_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_all_hugetlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -133,6 +137,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_OPS = {
     .get_mbind_nodemask = memkind_hbw_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_preferred_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -151,6 +156,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_HUGETLB_OPS = {
     .get_mbind_nodemask = memkind_hbw_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_preferred_hugetlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 
@@ -170,6 +176,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_INTERLEAVE_OPS = {
     .get_mbind_nodemask = memkind_hbw_all_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hbw_interleave_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 

--- a/src/memkind_hugetlb.c
+++ b/src/memkind_hugetlb.c
@@ -55,6 +55,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HUGETLB_OPS = {
     .get_mmap_flags = memkind_hugetlb_get_mmap_flags,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_hugetlb_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 

--- a/src/memkind_interleave.c
+++ b/src/memkind_interleave.c
@@ -42,6 +42,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_INTERLEAVE_OPS = {
     .get_mbind_nodemask = memkind_default_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_interleave_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize
 };
 

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -45,8 +45,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_PMEM_OPS = {
     .mmap = memkind_pmem_mmap,
     .get_mmap_flags = memkind_pmem_get_mmap_flags,
     .get_arena = memkind_thread_get_arena,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_pmem_destroy,
-    .malloc_usable_size = memkind_default_malloc_usable_size
 };
 
 void *pmem_extent_alloc(extent_hooks_t *extent_hooks,

--- a/src/memkind_regular.c
+++ b/src/memkind_regular.c
@@ -99,6 +99,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_REGULAR_OPS = {
     .get_mbind_nodemask = memkind_regular_all_get_mbind_nodemask,
     .get_arena = memkind_thread_get_arena,
     .init_once = memkind_regular_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_regular_finalize
 };
 

--- a/test/memkind_null_kind_test.cpp
+++ b/test/memkind_null_kind_test.cpp
@@ -61,6 +61,17 @@ TEST_F(MemkindNullKindTests, test_TC_MEMKIND_NullKindFreeNullPtr)
     } while (timer.getElapsedTime() < test_time);
 }
 
+TEST_F(MemkindNullKindTests, test_TC_MEMKIND_NullKindUsableSizeNullPtr)
+{
+    const double test_time = 5;
+
+    TimerSysTime timer;
+    timer.start();
+    do {
+        memkind_malloc_usable_size(nullptr, nullptr);
+    } while (timer.getElapsedTime() < test_time);
+}
+
 TEST_F(MemkindNullKindTests, test_TC_MEMKIND_DefaultRegularKindFreeNullPtr)
 {
     const size_t size_1 = 1 * KB;

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -350,13 +350,17 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocUsableSize)
     ASSERT_EQ(0, err);
     ASSERT_NE(nullptr, pmem_temp);
     size_t usable_size = memkind_malloc_usable_size(pmem_temp, nullptr);
+    size_t nullkind_usable_size = memkind_malloc_usable_size(nullptr, nullptr);
     ASSERT_EQ(0u, usable_size);
+    ASSERT_EQ(nullkind_usable_size, usable_size);
     for (unsigned int i = 0; i < ARRAY_SIZE(check_sizes); ++i) {
         size_t size = check_sizes[i].size;
         void *alloc = memkind_malloc(pmem_temp, size);
         ASSERT_NE(nullptr, alloc);
 
         usable_size = memkind_malloc_usable_size(pmem_temp, alloc);
+        nullkind_usable_size = memkind_malloc_usable_size(nullptr, alloc);
+        ASSERT_EQ(nullkind_usable_size, usable_size);
         size_t diff = usable_size - size;
         ASSERT_GE(usable_size, size);
         ASSERT_LE(diff, check_sizes[i].spacing);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Extend heap manager functionality by passing NULL as kind in memkind_malloc_usable_size

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/189)
<!-- Reviewable:end -->
