### PR TITLE
docker: call build.sh directly

### DIFF
--- a/utils/docker/docker_run_build_and_test.sh
+++ b/utils/docker/docker_run_build_and_test.sh
@@ -46,11 +46,7 @@ if [ -n "$PULL_REQUEST_NO" ]; then
 fi
 
 # building jemalloc and memkind
-./build_jemalloc.sh
-./autogen.sh
-./configure --prefix=/usr $GCOV_OPTION
-make -j "$(nproc --all)"
-make checkprogs -j "$(nproc --all)"
+./build.sh --prefix=/usr $GCOV_OPTION
 
 # installing memkind
 sudo make install


### PR DESCRIPTION
- enable-gcov is flag pass only to memkind - jemalloc throws a warning
that is not recognized

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/194)
<!-- Reviewable:end -->
