### PR TITLE
memkind_create_pmem_with_config default behaviour

### DIFF
--- a/man/memkind.3
+++ b/man/memkind.3
@@ -768,7 +768,7 @@ Default memory usage policy.
 .B MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE
 Conservative memory usage policy - prioritize memory usage at cost of performance.
 .BR Note:
-This policy is not supported by TBB heap manager described in
+Memory usage policies have no effect for TBB heap manager described in
 .B ENVIRONMENT
 section.
 .SH "ERRORS"

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -225,12 +225,8 @@ size_t tbb_pool_malloc_usable_size_with_kind_detect(void *ptr)
 static int tbb_update_memory_usage_policy(struct memkind *kind,
                                           memkind_mem_usage_policy policy)
 {
-    int status = MEMKIND_SUCCESS;
-    if (policy != MEMKIND_MEM_USAGE_POLICY_DEFAULT) {
-        log_err("memkind_mem_usage_policy is not supported by TBB.");
-        status = MEMKIND_ERROR_OPERATION_FAILED;
-    }
-    return status;
+    log_info("Memkind memory usage policies have no effect in TBB manager.");
+    return MEMKIND_SUCCESS;
 }
 
 static int tbb_destroy(struct memkind *kind)


### PR DESCRIPTION
- rephrase information in documentation
- return MEMKIND_SUCCESS, because kind created with
memkind_create_pmem_with_config is still valid

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/197)
<!-- Reviewable:end -->
