### PR TITLE
Add KeyDB additional pmem APIs

### DIFF
--- a/include/memkind.h
+++ b/include/memkind.h
@@ -385,6 +385,10 @@ void *memkind_realloc(memkind_t kind, void *ptr, size_t size);
 ///
 void memkind_free(memkind_t kind, void *ptr);
 
+int memkind_fd(struct memkind *kind);
+void memkind_pmem_remapfd(struct memkind *kind, int fdNew);
+int memkind_tmpfile(const char *dir, int *fd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/memkind/internal/memkind_pmem.h
+++ b/include/memkind/internal/memkind_pmem.h
@@ -53,11 +53,19 @@ int memkind_pmem_destroy(struct memkind *kind);
 void *memkind_pmem_mmap(struct memkind *kind, void *addr, size_t size);
 int memkind_pmem_get_mmap_flags(struct memkind *kind, int *flags);
 
+struct memkind_pmem_extent {
+    void *addrBase;
+    size_t cb;
+    off_t offset;
+};
 struct memkind_pmem {
     int fd;
     off_t offset;
     size_t max_size;
     pthread_mutex_t pmem_lock;
+    int cextents;
+    int cextentsAlloc;
+    struct memkind_pmem_extent *rgextents;
 };
 
 extern struct memkind_ops MEMKIND_PMEM_OPS;

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -697,7 +697,7 @@ MEMKIND_EXPORT void memkind_free(struct memkind *kind, void *ptr)
 #endif
 }
 
-static int memkind_tmpfile(const char *dir, int *fd)
+MEMKIND_EXPORT int memkind_tmpfile(const char *dir, int *fd)
 {
     static char template[] = "/memkind.XXXXXX";
     int err = 0;


### PR DESCRIPTION
This is a set of changes to make memkind_pmem more useful for production work.  Specifically these are the changes I used to integrate it with KeyDB.  It adds a way to handle memory deallocation without leaking as well as an API to help with fork() implementation (i.e. the method in KeyDB is to rebase to a new file created with an FS snapshot).  

### Description
Resolves Issue #221 plus additional APIs

### Types of changes
- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

## Further comments
It is not intended that this PR be merged as-is, but rather that it be the basis for additional discussion.  While the changes are mostly general they provide a very low level API.  Additionally it excludes other ways of handling fork() such as remapping pages as private and letting the kernel COW them to RAM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/222)
<!-- Reviewable:end -->
