### PR TITLE
Fix compatibility with non-C++11 ABI

### DIFF
--- a/include/pmem_allocator.h
+++ b/include/pmem_allocator.h
@@ -120,7 +120,7 @@ namespace libmemkind
             template<typename U>
             friend class allocator;
 
-#ifndef _GLIBCXX_USE_CXX11_ABI
+#if !_GLIBCXX_USE_CXX11_ABI
             /* This is a workaround for compilers (e.g GCC 4.8) that uses C++11 standard,
              * but use old - non C++11 ABI */
             template<typename V = void>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
The issue was reproduced on CentOS 7.6 with GCC 7.4.0.
The root cause of the issue is that C++ standard library has non-C++11 ABI.

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/255)
<!-- Reviewable:end -->
