### PR TITLE
Simplify bandwidth_create_nodes function

### DIFF
--- a/include/memkind/internal/memkind_bandwidth.h
+++ b/include/memkind/internal/memkind_bandwidth.h
@@ -40,8 +40,8 @@ struct bandwidth_closest_numanode_t {
 typedef int (*get_node_bitmask)(struct bitmask *);
 typedef int (*fill_bandwidth_values)(int *);
 
-int bandwidth_create_nodes(int num_bandwidth, const int *bandwidth,
-                           int *num_unique, struct bandwidth_nodes_t **bandwidth_nodes);
+int bandwidth_create_nodes(const int *bandwidth, int *num_unique,
+                           struct bandwidth_nodes_t **bandwidth_nodes);
 int bandwidth_fill(int *bandwidth, get_node_bitmask get_bitmask);
 int bandwidth_fill_nodes(int *bandwidth, fill_bandwidth_values fill,
                          const char *env);

--- a/src/memkind_dax_kmem.c
+++ b/src/memkind_dax_kmem.c
@@ -183,8 +183,7 @@ static void memkind_dax_kmem_closest_numanode_init(void)
     if (g->init_err)
         goto exit;
 
-    g->init_err = bandwidth_create_nodes(NUMA_NUM_NODES, bandwidth, &num_unique,
-                                         &bandwidth_nodes);
+    g->init_err = bandwidth_create_nodes(bandwidth, &num_unique, &bandwidth_nodes);
     if (g->init_err)
         goto exit;
 

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -372,8 +372,7 @@ static void memkind_hbw_closest_numanode_init(void)
     if (g->init_err)
         goto exit;
 
-    g->init_err = bandwidth_create_nodes(NUMA_NUM_NODES, bandwidth,
-                                         &num_unique, &bandwidth_nodes);
+    g->init_err = bandwidth_create_nodes(bandwidth, &num_unique, &bandwidth_nodes);
     if (g->init_err)
         goto exit;
 


### PR DESCRIPTION
- remove num_bandwidth input parameter which is always equal
NUMA_NUM_NODES

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/262)
<!-- Reviewable:end -->
