### PR TITLE
Fix scenario with multiple PMEM NUMA nodes

### DIFF
--- a/include/memkind/internal/memkind_bandwidth.h
+++ b/include/memkind/internal/memkind_bandwidth.h
@@ -29,6 +29,8 @@ extern "C" {
 
 #include <numa.h>
 
+#define NODE_NOT_PRESENT -1
+
 struct bandwidth_nodes_t;
 
 typedef int (*get_node_bitmask)(struct bitmask *);
@@ -39,9 +41,9 @@ int bandwidth_create_nodes(const int *bandwidth, int *num_unique,
 int bandwidth_fill(int *bandwidth, get_node_bitmask get_bitmask);
 int bandwidth_fill_nodes(int *bandwidth, fill_bandwidth_values fill,
                          const char *env);
-int bandwidth_set_closest_numanode(int num_unique,
-                                   const struct bandwidth_nodes_t *bandwidth_nodes,
-                                   int num_cpunode, int *closest_numanode);
+int bandwidth_set_closest_numanodes(int num_unique,
+                                    const struct bandwidth_nodes_t *bandwidth_nodes, int num_cpunode,
+                                    int num_numanode, int **closest_numanodes);
 
 #ifdef __cplusplus
 }

--- a/src/memkind_bandwidth.c
+++ b/src/memkind_bandwidth.c
@@ -218,9 +218,9 @@ int bandwidth_create_nodes(const int *bandwidth, int *num_unique,
     return err;
 }
 
-int bandwidth_set_closest_numanode(int num_unique,
-                                   const struct bandwidth_nodes_t *bandwidth_nodes,
-                                   int num_cpunode, int *closest_numanode)
+int bandwidth_set_closest_numanodes(int num_unique,
+                                    const struct bandwidth_nodes_t *bandwidth_nodes, int num_cpunode,
+                                    int num_numanode, int **closest_numanodes)
 {
     /***************************************************************************
     *   num_unique (IN):                                                       *
@@ -228,20 +228,24 @@ int bandwidth_set_closest_numanode(int num_unique,
     *   bandwidth_nodes (IN):                                                  *
     *       Output vector from create_bandwitdth_nodes().                      *
     *   num_cpunode (IN):                                                      *
-    *       Number of cpu's and length of closest_numanode.                    *
-    *   closest_numanode (OUT):                                                *
-    *       Vector that maps cpu index to closest numa node of the specified   *
-    *       bandwidth.                                                         *
+    *       Number of cpu's and rows number of closest_numanode.               *
+    *   num_numanode (IN):                                                     *
+    *       Number of NUMA node's and column number of closest_numanode.       *
+    *   closest_numanodes (OUT):                                               *
+    *       Matrix that maps cpu index to closest numa nodes id                *
+    *       of the specified bandwidth.                                        *
     *   RETURNS zero on success, error code on failure                         *
     ***************************************************************************/
     int err = MEMKIND_SUCCESS;
-    int min_distance, distance, i, j, old_errno, min_unique;
+    int min_distance, distance, i, j, k, old_errno, min_unique;
     struct bandwidth_nodes_t match;
     match.bandwidth = -1;
     int target_bandwidth = bandwidth_nodes[num_unique-1].bandwidth;
 
     for (i = 0; i < num_cpunode; ++i) {
-        closest_numanode[i] = -1;
+        for (j = 0; j < num_numanode; ++j) {
+            closest_numanodes[i][j] = NODE_NOT_PRESENT;
+        }
     }
     for (i = 0; i < num_unique; ++i) {
         if (bandwidth_nodes[i].bandwidth == target_bandwidth) {
@@ -257,19 +261,21 @@ int bandwidth_set_closest_numanode(int num_unique,
             min_unique = 1;
             for (j = 0; j < match.num_numanodes; ++j) {
                 old_errno = errno;
-                distance = numa_distance(numa_node_of_cpu(i),
-                                         match.numanodes[j]);
+                distance = numa_distance(numa_node_of_cpu(i), match.numanodes[j]);
                 errno = old_errno;
                 if (distance < min_distance) {
                     min_distance = distance;
-                    closest_numanode[i] = match.numanodes[j];
+                    if (min_unique > 1) {
+                        for (k = 0; k < num_numanode; ++k) {
+                            closest_numanodes[i][k] = NODE_NOT_PRESENT;
+                        }
+                    }
+                    closest_numanodes[i][0] = match.numanodes[j];
                     min_unique = 1;
                 } else if (distance == min_distance) {
-                    min_unique = 0;
+                    closest_numanodes[i][min_unique] = match.numanodes[j];
+                    min_unique++;
                 }
-            }
-            if (!min_unique) {
-                err = MEMKIND_ERROR_RUNTIME;
             }
         }
     }

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -184,7 +184,7 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_INTERLEAVE_OPS = {
 struct hbw_closest_numanode_t {
     int init_err;
     int num_cpu;
-    int *closest_numanode;
+    int **closest_numanodes;
 };
 
 static struct hbw_closest_numanode_t memkind_hbw_closest_numanode_g;
@@ -223,7 +223,11 @@ MEMKIND_EXPORT int memkind_hbw_get_mbind_nodemask(struct memkind *kind,
         numa_bitmask_clearall(&nodemask_bm);
         int cpu = sched_getcpu();
         if (MEMKIND_LIKELY(cpu < g->num_cpu)) {
-            numa_bitmask_setbit(&nodemask_bm, g->closest_numanode[cpu]);
+            int i = 0;
+            while (g->closest_numanodes[cpu][i] != NODE_NOT_PRESENT) {
+                numa_bitmask_setbit(&nodemask_bm, g->closest_numanodes[cpu][i]);
+                i++;
+            }
         } else {
             return MEMKIND_ERROR_RUNTIME;
         }
@@ -244,7 +248,11 @@ MEMKIND_EXPORT int memkind_hbw_all_get_mbind_nodemask(struct memkind *kind,
         int cpu;
         numa_bitmask_clearall(&nodemask_bm);
         for (cpu = 0; cpu < g->num_cpu; ++cpu) {
-            numa_bitmask_setbit(&nodemask_bm, g->closest_numanode[cpu]);
+            int i = 0;
+            while (g->closest_numanodes[cpu][i] != NODE_NOT_PRESENT) {
+                numa_bitmask_setbit(&nodemask_bm, g->closest_numanodes[cpu][i]);
+                i++;
+            }
         }
     }
     return g->init_err;
@@ -361,13 +369,20 @@ static void memkind_hbw_closest_numanode_init(void)
     struct hbw_closest_numanode_t *g = &memkind_hbw_closest_numanode_g;
     int *bandwidth = (int *)jemk_calloc(NUMA_NUM_NODES, sizeof(int));
     int num_unique = 0;
+    int i;
 
     struct bandwidth_nodes_t *bandwidth_nodes = NULL;
+    int num_nodes = numa_num_configured_nodes();
 
     g->num_cpu = numa_num_configured_cpus();
-    g->closest_numanode = (int *)jemk_malloc(sizeof(int) * g->num_cpu);
+    g->closest_numanodes = (int **)jemk_malloc(sizeof(int *) * g->num_cpu +
+                                               (g->num_cpu * num_nodes * (sizeof(int))));
+    int *offset = (int *)&(g->closest_numanodes[g->num_cpu]);
+    for(i = 0; i < g->num_cpu; i++, offset += num_nodes) {
+        g->closest_numanodes[i] = offset;
+    }
 
-    if (!(g->closest_numanode && bandwidth)) {
+    if (!(g->closest_numanodes && bandwidth)) {
         g->init_err = MEMKIND_ERROR_MALLOC;
         log_err("jemk_malloc() failed.");
         goto exit;
@@ -382,8 +397,8 @@ static void memkind_hbw_closest_numanode_init(void)
     if (g->init_err)
         goto exit;
 
-    g->init_err = bandwidth_set_closest_numanode(num_unique, bandwidth_nodes,
-                                                 g->num_cpu, g->closest_numanode);
+    g->init_err = bandwidth_set_closest_numanodes(num_unique, bandwidth_nodes,
+                                                  g->num_cpu, num_nodes, g->closest_numanodes);
 
 exit:
 
@@ -391,8 +406,8 @@ exit:
     jemk_free(bandwidth);
 
     if (g->init_err) {
-        jemk_free(g->closest_numanode);
-        g->closest_numanode = NULL;
+        jemk_free(g->closest_numanodes);
+        g->closest_numanodes = NULL;
     }
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
Use memset operation to intitialize closest NUMA nodes array. Extend closest NUMA node to NUMA nodes, to cover using MEMKIND_DAX_KMEM with multiple PMEM NUMA nodes with same minimal length to CPU.


### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/267)
<!-- Reviewable:end -->
