### PR TITLE
Fixes to allow memkind to be used on el6-derived platforms

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ libmemkind_la_SOURCES = src/hbwmalloc.c \
 
 
 libmemkind_la_LIBADD = jemalloc/lib/libjemalloc_pic.a
-libmemkind_la_LDFLAGS = -version-info 0:1:0 -ldl
+libmemkind_la_LDFLAGS = -version-info 0:1:0 -ldl -lrt
 include_HEADERS = include/hbw_allocator.h \
                   include/hbwmalloc.h \
                   include/memkind.h \

--- a/configure.ac
+++ b/configure.ac
@@ -25,10 +25,10 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.64])
+AC_PREREQ([2.63])
 AC_INIT([memkind],m4_esyscmd([tr -d '\n' < VERSION]))
 
-AC_CONFIG_MACRO_DIRS([m4])
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([memkind.spec.mk])
 
@@ -36,7 +36,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign 1.11 silent-rules subdir-objects paralle
 AM_SILENT_RULES([yes])
 
 # Checks for programs and libraries.
-AM_PROG_AR
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_PROG_CXX
 AC_PROG_CC
 AC_OPENMP

--- a/jemalloc/configure.ac
+++ b/jemalloc/configure.ac
@@ -1454,10 +1454,14 @@ if test "x$abi" != "xpecoff" ; then
   have_pthread="1"
   dnl Check if we have dlsym support.
   have_dlsym="1"
-  AC_CHECK_HEADERS([dlfcn.h],
-    AC_CHECK_FUNC([dlsym], [],
-      [AC_CHECK_LIB([dl], [dlsym], [LIBS="$LIBS -ldl"], [have_dlsym="0"])]),
-    [have_dlsym="0"])
+  AC_CHECK_HEADERS([dlfcn.h], , [have_dlsym="0"])
+  check_dlsym_in_libdl="0"
+  if test "x$have_dlsym" = "x1" ; then
+    AC_CHECK_FUNC([dlsym], [], [check_dlsym_in_libdl="1"])
+  fi
+  if test "x$check_dlsym_in_libdl" = "x1" ; then
+    AC_CHECK_LIB([dl], [dlsym], [LIBS="$LIBS -ldl"], [have_dlsym="0"])
+  fi
   if test "x$have_dlsym" = "x1" ; then
     AC_DEFINE([JEMALLOC_HAVE_DLSYM], [ ])
   fi


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR makes a few autotools changes that allow memkind to be built and used on el6-derived platforms (RHEL 6.x, CentOS 6.x, OEL 6.x, etc.). I understand that, a new kernel is generally necessary to take advantage of memkind features. Nevertheless, we've incorporated memkind into Apache Kudu which supports distros all the way back to el6.6, and these patches have allowed the inclusion of memkind to be unconditional and platform-agnostic, reducing overall build complexity.


### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ x ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ x ] Code compiles without errors
- [ x ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/285)
<!-- Reviewable:end -->
