### PR TITLE
Update memkind_pmem_test configuration and fix make unit_test

### DIFF
--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -34,9 +34,11 @@ check_PROGRAMS += test/all_tests \
                   test/gb_page_tests_bind_policy \
                   test/locality_test \
                   test/memkind_stat_test \
-                  test/pmem_test \
                   test/trace_mechanism_test_helper \
                   # end
+if HAVE_CXX11
+check_PROGRAMS += test/pmem_test
+endif
 
 TESTS += test/test.sh
 
@@ -69,8 +71,12 @@ test_environ_err_hbw_malloc_test_LDADD = libmemkind.la
 test_freeing_memory_segfault_test_LDADD = libmemkind.la
 test_gb_page_tests_bind_policy_LDADD = libmemkind.la
 test_memkind_stat_test_LDADD = libmemkind.la
-test_pmem_test_LDADD = libmemkind.la
 test_trace_mechanism_test_helper_LDADD = libmemkind.la
+
+if HAVE_CXX11
+test_pmem_test_SOURCES = $(fused_gtest) test/memkind_pmem_config_tests.cpp test/memkind_pmem_long_time_tests.cpp test/memkind_pmem_tests.cpp
+test_pmem_test_LDADD = libmemkind.la
+endif
 
 fused_gtest = test/gtest_fused/gtest/gtest-all.cc \
               test/main.cpp \
@@ -119,7 +125,6 @@ test_environ_err_hbw_malloc_test_SOURCES = test/environ_err_hbw_malloc_test.cpp
 test_freeing_memory_segfault_test_SOURCES = $(fused_gtest) test/freeing_memory_segfault_test.cpp
 test_gb_page_tests_bind_policy_SOURCES = $(fused_gtest) test/gb_page_tests_bind_policy.cpp test/trial_generator.cpp test/check.cpp
 test_memkind_stat_test_SOURCES = $(fused_gtest) test/memkind_stat_test.cpp
-test_pmem_test_SOURCES = $(fused_gtest) test/memkind_pmem_config_tests.cpp test/memkind_pmem_long_time_tests.cpp test/memkind_pmem_tests.cpp
 test_trace_mechanism_test_helper_SOURCES = test/trace_mechanism_test_helper.c
 
 #Tests based on Allocator Perf Tool

--- a/test/bat_tests.cpp
+++ b/test/bat_tests.cpp
@@ -420,14 +420,6 @@ TEST_F(BATest,
     memkind_free(0, ptr);
 }
 
-TEST_F(BATest,
-       test_TC_MEMKIND_free_MEMKIND_DAX_KMEM_free_with_NULL_kind_4096_bytes)
-{
-    void *ptr = memkind_malloc(MEMKIND_DAX_KMEM, 4096);
-    ASSERT_TRUE(ptr != NULL) << "malloc() returns NULL";
-    memkind_free(0, ptr);
-}
-
 TEST_F(BATest, test_TC_MEMKIND_free_ext_MEMKIND_GBTLB_4096_bytes)
 {
     HugePageOrganizer huge_page_organizer(1000);

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -750,7 +750,7 @@ TEST_P(MemkindPmemTestsMalloc, test_TC_MEMKIND_PmemMallocSizeConservative)
     ASSERT_EQ(err, 0);
     memkind_config_delete(test_cfg);
 
-    //check maximum number of allocations right after create the kind
+    //check maximum number of allocations right after creating the kind
     while ((ptr = memkind_malloc(kind, alloc_size)) != nullptr) {
         pmem_vec.push_back(ptr);
     }
@@ -814,7 +814,7 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocSmallSizeFillConservative)
     ASSERT_EQ(err, 0);
     memkind_config_delete(test_cfg);
 
-    //check maximum number of allocations right after create the kind
+    //check maximum number of allocations right after creating the kind
     j = 0;
     while ((ptr = memkind_malloc(kind, small_size[j++])) != nullptr) {
         pmem_vec.push_back(ptr);

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -31,6 +31,7 @@
 #include <sys/statfs.h>
 #include <stdio.h>
 #include <pthread.h>
+#include <vector>
 #include "common.h"
 
 static const size_t PMEM_PART_SIZE = MEMKIND_PMEM_MIN_SIZE + 4 * KB;
@@ -64,7 +65,7 @@ class MemkindPmemTestsCalloc : public MemkindPmemTests,
 {
 };
 
-class MemkindPmemTestsMalloc : public MemkindPmemTests,
+class MemkindPmemTestsMalloc : public ::testing::Test,
     public ::testing::WithParamInterface<size_t>
 {
 };
@@ -729,49 +730,55 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemReallocNullKindSizeZero)
  * This test will stress pmem kind with malloc-free loop
  * with various sizes for malloc
  */
-TEST_P(MemkindPmemTestsMalloc, test_TC_MEMKIND_PmemMallocSize)
+TEST_P(MemkindPmemTestsMalloc, test_TC_MEMKIND_PmemMallocSizeConservative)
 {
-    const int malloc_limit = 1000000;
     const int loop_limit = 10;
-    int first_limit_of_allocations = 0;
-    int temp_limit_of_allocations = 0;
-    void *test[malloc_limit] = {nullptr};
-    int i = 0, j = 0;
+    int initial_alloc_limit = 0;
+    std::vector<void *> pmem_vec;
+    void *ptr;
+    size_t alloc_size = GetParam();
+    int i, err;
+    memkind_t kind = nullptr;
+
+    memkind_config *test_cfg = memkind_config_new();
+    ASSERT_NE(nullptr, test_cfg);
+    memkind_config_set_path(test_cfg, PMEM_DIR);
+    memkind_config_set_size(test_cfg, PMEM_PART_SIZE);
+    memkind_config_set_memory_usage_policy(test_cfg,
+                                           MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE);
+    err =  memkind_create_pmem_with_config(test_cfg, &kind);
+    ASSERT_EQ(err, 0);
+    memkind_config_delete(test_cfg);
 
     //check maximum number of allocations right after create the kind
-    for (i = 0; i < malloc_limit; i++) {
-        test[i] = memkind_malloc(pmem_kind, GetParam());
-        if(test[i] == nullptr)
-            break;
+    while ((ptr = memkind_malloc(kind, alloc_size)) != nullptr) {
+        pmem_vec.push_back(ptr);
     }
 
-    ASSERT_NE(malloc_limit, i);
-    first_limit_of_allocations = i;
+    initial_alloc_limit = pmem_vec.size();
 
-    for (i = 0; i < first_limit_of_allocations; i++) {
-        memkind_free(pmem_kind, test[i]);
-        test[i] = nullptr;
+    for(auto const &val: pmem_vec) {
+        memkind_free(kind, val);
     }
+    pmem_vec.clear();
 
     //check number of allocations in consecutive iterations of malloc-free loop
     for (i = 0; i < loop_limit; i++) {
-        for (j = 0; j < malloc_limit; j++) {
-            test[j] = memkind_malloc(pmem_kind, GetParam());
-            if(test[j] == nullptr)
-                break;
+
+        while ((ptr = memkind_malloc(kind, alloc_size)) != nullptr) {
+            pmem_vec.push_back(ptr);
         }
+        int temp_limit_of_allocations = pmem_vec.size();
 
-        ASSERT_NE(malloc_limit, j);
-
-        temp_limit_of_allocations = j;
-
-        for (j = 0; j < temp_limit_of_allocations; j++) {
-            memkind_free(pmem_kind, test[j]);
-            test[j] = nullptr;
+        for(auto const &val: pmem_vec) {
+            memkind_free(kind, val);
         }
+        pmem_vec.clear();
 
-        ASSERT_GE(temp_limit_of_allocations, 0.98 * first_limit_of_allocations);
+        ASSERT_GE(temp_limit_of_allocations, 0.98 * initial_alloc_limit);
     }
+    err = memkind_destroy_kind(kind);
+    ASSERT_EQ(0, err);
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -781,69 +788,66 @@ INSTANTIATE_TEST_CASE_P(
                       96 * KB, 112 * KB, 128 * KB, 160 * KB, 192 * KB, 500000,
                       2 * MB, 5 * MB));
 
-TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocSmallSizeFill)
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocSmallSizeFillConservative)
 {
     const size_t small_size[] = {8, 16, 32, 48, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384,
                                  448, 512, 640, 768, 896, 1 * KB, 1280, 1536, 1792, 2 * KB, 2560,
                                  3 * KB, 3584, 4 * KB, 5 * KB, 6 * KB, 7 * KB, 8 * KB, 10 * KB,
                                  12 * KB, 14 * KB
                                 };
-    const int malloc_limit = 10000;
     const int loop_limit = 100;
-    int first_limit_of_allocations = 0;
-    int temp_limit_of_allocations = 0;
-    void *test[malloc_limit][ARRAY_SIZE(small_size)] = {{nullptr}};
-    int i = 0, j = 0, k = 0;
+    int initial_alloc_limit = 0;
+    int err;
+    std::vector<void *> pmem_vec;
+    void *ptr;
+    unsigned i, j;
+    memkind_t kind = nullptr;
+
+    memkind_config *test_cfg = memkind_config_new();
+    ASSERT_NE(nullptr, test_cfg);
+
+    memkind_config_set_path(test_cfg, PMEM_DIR);
+    memkind_config_set_size(test_cfg, PMEM_PART_SIZE);
+    memkind_config_set_memory_usage_policy(test_cfg,
+                                           MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE);
+    err =  memkind_create_pmem_with_config(test_cfg, &kind);
+    ASSERT_EQ(err, 0);
+    memkind_config_delete(test_cfg);
 
     //check maximum number of allocations right after create the kind
-    [&] {
-        for (i = 0; i < malloc_limit; i++)
-        {
-            for (j = 0; j < (int)ARRAY_SIZE(small_size); j++) {
-                test[i][j] = memkind_malloc(pmem_kind, small_size[j]);
-                if (test[i][j] == nullptr)
-                    return;
-            }
-        }
-    }();
-
-    ASSERT_NE(malloc_limit, i);
-    first_limit_of_allocations = i;
-
-    for(; i >= 0; i--) {
-        for(j--; j >= 0; j--) {
-            memkind_free(pmem_kind, test[i][j]);
-            test[i][j] = nullptr;
-        }
-        j = ARRAY_SIZE(small_size);
+    j = 0;
+    while ((ptr = memkind_malloc(kind, small_size[j++])) != nullptr) {
+        pmem_vec.push_back(ptr);
+        if (j == ARRAY_SIZE(small_size)) j = 0;
     }
+
+    initial_alloc_limit = pmem_vec.size();
+
+    for(auto const &val: pmem_vec) {
+        memkind_free(kind, val);
+    }
+    pmem_vec.clear();
 
     //check number of allocations in consecutive iterations of malloc-free loop
     for (i = 0; i < loop_limit; i++) {
-        [&] {
-            for (j = 0; j < malloc_limit; j++)
-            {
-                for (k = 0; k < (int)ARRAY_SIZE(small_size); k++) {
-                    test[j][k] = memkind_malloc(pmem_kind, small_size[k]);
-                    if(test[j][k] == nullptr)
-                        return;
-                }
-            }
-        }();
 
-        ASSERT_NE(malloc_limit, j);
-        temp_limit_of_allocations = j;
-
-        for(; j >= 0; j--) {
-            for(k--; k >= 0; k--) {
-                memkind_free(pmem_kind, test[j][k]);
-                test[j][k] = nullptr;
-            }
-            k = ARRAY_SIZE(small_size);
+        j = 0;
+        while ((ptr = memkind_malloc(kind, small_size[j++])) != nullptr) {
+            pmem_vec.push_back(ptr);
+            if (j == ARRAY_SIZE(small_size)) j = 0;
         }
 
-        ASSERT_GE(temp_limit_of_allocations, 0.98 * first_limit_of_allocations);
+        int temp_limit_of_allocations = pmem_vec.size();
+
+        for(auto const &val: pmem_vec) {
+            memkind_free(kind, val);
+        }
+        pmem_vec.clear();
+
+        ASSERT_GE(temp_limit_of_allocations, 0.98 * initial_alloc_limit);
     }
+    err = memkind_destroy_kind(kind);
+    ASSERT_EQ(0, err);
 }
 
 TEST_F(MemkindPmemTests,
@@ -934,33 +938,22 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPosixMemalignSizeMax)
  */
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPosixMemalign)
 {
-    const int max_allocs = 1000000;
     const int test_value = 123456;
     const int test_loop = 10;
     uintptr_t alignment;
-    unsigned malloc_counter = 0;
-    unsigned i = 0, j = 0;
-    int *ptrs[max_allocs] = {nullptr};
+    unsigned i = 0;
     void *test = nullptr;
+    std::vector<void *> pmem_vec;
     int ret;
 
     for(alignment =  1 * KB; alignment <= 128 * KB; alignment *= 2) {
         for (i = 0; i < test_loop; i++) {
-            for (j = 0; j < max_allocs; ++j) {
-                errno = 0;
-                ret = memkind_posix_memalign(pmem_kind, &test, alignment, sizeof(int *));
-                if(ret != 0) {
-                    //at least one allocation must succeed
-                    //ASSERT_TRUE(j > 0); TODO: this is issue with posix_mem_align and test should
-                    //be updated after resolving this, check PR#86
-                    malloc_counter = j;
-                    break;
-                }
-
-                ASSERT_EQ(ret, 0);
+            errno = 0;
+            while((ret = memkind_posix_memalign(pmem_kind, &test, alignment,
+                                                sizeof(int *))) == 0) {
                 ASSERT_EQ(errno, 0);
 
-                ptrs[j] = (int *)test;
+                pmem_vec.push_back(test);
 
                 //test pointer should be usable
                 *(int *)test = test_value;
@@ -968,12 +961,13 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPosixMemalign)
 
                 //check for correct address alignment
                 ASSERT_EQ((uintptr_t)(test) & (alignment - 1), (uintptr_t)0);
+                errno = 0;
             }
 
-            for (j = 0; j < malloc_counter; ++j) {
-                memkind_free(pmem_kind, ptrs[j]);
-                ptrs[j] = nullptr;
+            for(auto const &val: pmem_vec) {
+                memkind_free(pmem_kind, val);
             }
+            pmem_vec.clear();
         }
     }
 }
@@ -1343,9 +1337,11 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMultithreadsStressKindsCreate)
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemKindFreeBenchmarkOneThread)
 {
     const size_t pmem_array_size = 10;
+    const size_t alloc_size = 512;
     struct memkind *pmem_kind_array[pmem_array_size] = { nullptr };
-    const size_t malloc_limit = 100000;
-    void *ptr[pmem_array_size][malloc_limit] = { { nullptr } };
+    std::vector<void *> pmem_vec_exp[pmem_array_size];
+    std::vector<void *> pmem_vec_imp[pmem_array_size];
+    void *ptr;
     TimerSysTime timer;
     double test1Time, test2Time;
 
@@ -1355,47 +1351,32 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemKindFreeBenchmarkOneThread)
     }
 
     for (size_t i = 0; i < pmem_array_size; ++i) {
-        size_t j = 0;
-        for (j = 0; j < malloc_limit; ++j) {
-            ptr[i][j] = memkind_malloc(pmem_kind_array[i], 512);
-
-            if (ptr[i][j] == nullptr) {
-                break;
-            }
+        while ((ptr = memkind_malloc(pmem_kind_array[i], alloc_size)) != nullptr) {
+            pmem_vec_exp[i].push_back(ptr);
         }
-        ASSERT_NE(j, malloc_limit);
     }
 
     timer.start();
     for (size_t i = 0; i < pmem_array_size; ++i) {
-        for (size_t j = 0; j < malloc_limit; ++j) {
-            if (ptr[i][j] == nullptr) {
-                break;
-            }
-            memkind_free(pmem_kind_array[i], ptr[i][j]);
+        for(auto const &val: pmem_vec_exp[i]) {
+            memkind_free(pmem_kind_array[i], val);
         }
     }
+
     test1Time = timer.getElapsedTime();
     printf("Free time with explicitly kind: %f\n", test1Time);
 
+
     for (size_t i = 0; i < pmem_array_size; ++i) {
-        size_t j = 0;
-        for (j = 0; j < malloc_limit; ++j) {
-            ptr[i][j] = memkind_malloc(pmem_kind_array[i], 512);
-            if (ptr[i][j] == nullptr) {
-                break;
-            }
+        while ((ptr = memkind_malloc(pmem_kind_array[i], alloc_size)) != nullptr) {
+            pmem_vec_imp[i].push_back(ptr);
         }
-        ASSERT_NE(j, malloc_limit);
     }
 
     timer.start();
     for (size_t i = 0; i < pmem_array_size; ++i) {
-        for (size_t j = 0; j < malloc_limit; ++j) {
-            if (ptr[i][j] == nullptr) {
-                break;
-            }
-            memkind_free(nullptr, ptr[i][j]);
+        for(auto const &val: pmem_vec_imp[i]) {
+            memkind_free(nullptr, val);
         }
     }
     test2Time = timer.getElapsedTime();
@@ -1540,9 +1521,9 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemKindFreeBenchmarkWithThreads)
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeUsingNullptrInsteadOfKind)
 {
     const size_t pmem_array_size = 10;
+    const size_t alloc_size = 1 * KB;
     struct memkind *pmem_kind_array[pmem_array_size] = { nullptr };
-    const int malloc_limit = 100000;
-    void *ptr[pmem_array_size][malloc_limit] = {{ nullptr }};
+    std::vector<void *> pmem_vec[pmem_array_size];
     void *testPtr = nullptr;
 
     for (size_t i = 0; i < pmem_array_size; ++i) {
@@ -1551,38 +1532,30 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeUsingNullptrInsteadOfKind)
     }
 
     for (size_t i = 0; i < pmem_array_size; ++i) {
-        int index = 0;
-        for (index = 0; index < malloc_limit; ++index) {
-            ptr[i][index] = memkind_malloc(pmem_kind_array[i], 1 * KB);
-
-            if (ptr[i][index] == nullptr) {
-                break;
-            }
+        while ((testPtr = memkind_malloc(pmem_kind_array[i], alloc_size)) != nullptr) {
+            pmem_vec[i].push_back(testPtr);
         }
-        ASSERT_NE(malloc_limit, index);
     }
 
-    memkind_free(nullptr, ptr[5][5]);
+    memkind_free(nullptr, pmem_vec[5].at(5));
 
     for (size_t i = 0; i < pmem_array_size; ++i) {
         // attempt to alloc memory to the kinds
-        testPtr = memkind_malloc(pmem_kind_array[i], 1 * KB);
+        testPtr = memkind_malloc(pmem_kind_array[i], alloc_size);
         if (i == 5) {
             // allocation should be successful - confirmation that memkind_free(nullptr,...) works fine
             ASSERT_NE(testPtr, nullptr);
-            ptr[5][5] = testPtr;
+            pmem_vec[i].at(5) = testPtr;
         } else {
             // There is no more free space in other kinds
             ASSERT_EQ(testPtr, nullptr);
         }
     }
+
     // free the rest of the space and destroy kinds.
     for (size_t i = 0; i < pmem_array_size; ++i) {
-        for (int j = 0; j < malloc_limit; ++j) {
-            if (ptr[i][j] == nullptr)
-                break;
-
-            memkind_free(pmem_kind_array[i], ptr[i][j]);
+        for(auto const &val: pmem_vec[i]) {
+            memkind_free(pmem_kind_array[i], val);
         }
         int err = memkind_destroy_kind(pmem_kind_array[i]);
         ASSERT_EQ(0, err);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Remove test_TC_MEMKIND_free_MEMKIND_DAX_KMEM_free_with_NULL_kind_4096_bytes to fix make unit_test configuration
Improve memkind_pmem_test by:
Add requirement to pmem_test to compile it with c++11
Simplify code using vector solution
Update tests which check fill of pmem kind to use conservative policy

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/289)
<!-- Reviewable:end -->
