### PR TITLE
Fix: before using numa functions numa_avaliable() should be called

### DIFF
--- a/src/memkind-auto-dax-kmem-nodes.c
+++ b/src/memkind-auto-dax-kmem-nodes.c
@@ -66,6 +66,11 @@ static int print_dax_kmem_nodes()
 
     nodemask_t nodemask;
     struct bitmask nodemask_dax_kmem = {NUMA_NUM_NODES, nodemask.n};
+
+    // ensuring functions in numa library are defined
+    if (numa_available() == -1) {
+        return 3;
+    }
     numa_bitmask_clearall(&nodemask_dax_kmem);
 
     //WARNING: code below is usage of memkind experimental API which may be changed in future

--- a/src/memkind-hbw-nodes.c
+++ b/src/memkind-hbw-nodes.c
@@ -66,6 +66,11 @@ int print_hbw_nodes()
 
     nodemask_t nodemask;
     struct bitmask nodemask_bm = {NUMA_NUM_NODES, nodemask.n};
+
+    // ensuring functions in numa library are defined
+    if (numa_available() == -1) {
+        return 3;
+    }
     numa_bitmask_clearall(&nodemask_bm);
 
     //WARNING: code below is usage of memkind experimental API which may be changed in future

--- a/src/memkind_hugetlb.c
+++ b/src/memkind_hugetlb.c
@@ -75,7 +75,7 @@ MEMKIND_EXPORT int memkind_hugetlb_get_mmap_flags(struct memkind *kind,
 
 MEMKIND_EXPORT void memkind_hugetlb_init_once(void)
 {
-    memkind_init(MEMKIND_HUGETLB, false);
+    memkind_init(MEMKIND_HUGETLB, true);
 }
 
 MEMKIND_EXPORT int memkind_hugetlb_check_available_2mb(struct memkind *kind)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Accorging to [http://man7.org/linux/man-pages/man3/numa.3.html](http://man7.org/linux/man-pages/man3/numa.3.html) numa_avaliable() should be called before any other numa related function.
Changes made in binaries printing NUMA and hbw nodes and also before initializing MEMKIND_HUGETLB kind.

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/292)
<!-- Reviewable:end -->
