### PR TITLE
Update gtest with GTEST_SKIP() implementation

### DIFF
--- a/test/gtest_fused/gtest/gtest.h
+++ b/test/gtest_fused/gtest/gtest.h
@@ -9447,6 +9447,9 @@ namespace testing
 #define GTEST_SUCCESS_(message) \
   GTEST_MESSAGE_(message, ::testing::TestPartResult::kSuccess)
 
+#define GTEST_SKIP_(message) \
+  return GTEST_MESSAGE_(message, ::testing::TestPartResult::kSkip)
+
 // Suppresses MSVC warnings 4072 (unreachable code) for the code following
 // statement if it returns or throws (or doesn't return or throw in some
 // situations).
@@ -19482,7 +19485,8 @@ namespace testing
         enum Type {
             kSuccess,          // Succeeded.
             kNonFatalFailure,  // Failed but the test can continue.
-            kFatalFailure      // Failed and the test should be terminated.
+            kFatalFailure,     // Failed and the test should be terminated.
+            kSkip              // Skipped.
         };
 
         // C'tor.  TestPartResult does NOT have a default constructor.
@@ -19532,6 +19536,12 @@ namespace testing
             return message_.c_str();
         }
 
+        // Returns true if and only if the test part was skipped.
+        bool skipped() const
+        {
+            return type_ == kSkip;
+        }
+
         // Returns true iff the test part passed.
         bool passed() const
         {
@@ -19541,7 +19551,7 @@ namespace testing
         // Returns true iff the test part failed.
         bool failed() const
         {
-            return type_ != kSuccess;
+            return fatally_failed() || nonfatally_failed();
         }
 
         // Returns true iff the test part non-fatally failed.
@@ -20266,6 +20276,9 @@ namespace testing
         // Returns true iff the current test has a non-fatal failure.
         static bool HasNonfatalFailure();
 
+        // Returns true if and only if the current test was skipped.
+        static bool IsSkipped();
+
         // Returns true iff the current test has a (either fatal or
         // non-fatal) failure.
         static bool HasFailure()
@@ -20414,11 +20427,14 @@ namespace testing
         // Returns the number of the test properties.
         int test_property_count() const;
 
-        // Returns true iff the test passed (i.e. no test part failed).
+        // Returns true if the test passed (i.e. no test part failed).
         bool Passed() const
         {
-            return !Failed();
+            return !Skipped() && !Failed();
         }
+
+        // Returns true if and only if the test was skipped.
+        bool Skipped() const;
 
         // Returns true iff the test failed.
         bool Failed() const;
@@ -20428,6 +20444,9 @@ namespace testing
 
         // Returns true iff the test has a non-fatal failure.
         bool HasNonfatalFailure() const;
+
+        // Returns true if and only if the current test was skipped.
+        static bool IsSkipped();
 
         // Returns the elapsed time, in milliseconds.
         TimeInMillis elapsed_time() const
@@ -20741,6 +20760,9 @@ namespace testing
         // Gets the number of successful tests in this test case.
         int successful_test_count() const;
 
+        // Gets the number of skipped tests in this test suite.
+        int skipped_test_count() const;
+
         // Gets the number of failed tests in this test case.
         int failed_test_count() const;
 
@@ -20848,6 +20870,12 @@ namespace testing
         static bool TestPassed(const TestInfo *test_info)
         {
             return test_info->should_run() && test_info->result()->Passed();
+        }
+
+        // Returns true if and only if test skipped.
+        static bool TestSkipped(const TestInfo *test_info)
+        {
+            return test_info->should_run() && test_info->result()->Skipped();
         }
 
         // Returns true iff test failed.
@@ -21174,6 +21202,9 @@ namespace testing
 
         // Gets the number of successful tests.
         int successful_test_count() const;
+
+        // Gets the number of skipped tests.
+        int skipped_test_count() const;
 
         // Gets the number of failed tests.
         int failed_test_count() const;
@@ -21781,6 +21812,11 @@ GTEST_API_ AssertionResult CmpHelper##op_name(\
 #endif  // GTEST_HAS_PARAM_TEST
 
 // Macros for indicating success/failure in test code.
+
+// Skips test in runtime.
+// Skipping test aborts current function.
+// Skipped tests are neither successful nor failed.
+#define GTEST_SKIP() GTEST_SKIP_("")
 
 // ADD_FAILURE unconditionally adds a failure to the current test.
 // SUCCEED generates a success - it doesn't automatically make the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding GTEST_SKIP() macro to provide possibility skipping tests, without marking them as failed.
Very basic usage introduced on pmem_dax_kmem test, which will be improved
 in separate PR.
### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/295)
<!-- Reviewable:end -->
