### PR TITLE
Add log info when no DAX_KMEM nodes are found

### DIFF
--- a/test/test_dax_kmem.sh
+++ b/test/test_dax_kmem.sh
@@ -218,6 +218,7 @@ function check_auto_dax_kmem_nodes()
     fi
 
     ret=$(memkind-auto-dax-kmem-nodes)
+    emit "The binary memkind-auto-dax-kmem-nodes returned code $ret."
     if [[ $ret == "" ]]; then
         export MEMKIND_DAX_KMEM_NODES=1
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
This logs the information about setting MEMKIND_DAX_KMEM_NODES to some
arbitrary value when no DAX_KMEM nodes are detected.

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/306)
<!-- Reviewable:end -->
