### PR TITLE
Improve check for preferred node

### DIFF
--- a/man/memkind.3
+++ b/man/memkind.3
@@ -808,7 +808,8 @@ except that if there is not enough memory in the closest persistent memory NUMA 
 the request, the allocation will fall back on other memory NUMA nodes.
 .BR Note:
 For this kind, the allocation will not succeed if two or more
-persistent memory NUMA nodes are in the same shortest distance to the same CPU.
+persistent memory NUMA nodes are in the same shortest distance to the same CPU on which process is eligible to run.
+Check on that eligibility is done upon starting the application.
 .TP
 .B MEMKIND_REGULAR
 Allocate from regular memory using the default page size. Regular means general purpose memory

--- a/man/memkindallocator.3
+++ b/man/memkindallocator.3
@@ -138,7 +138,9 @@ Same as
 .B libmemkind::kinds::DAX_KMEM
 except that if there is not enough memory in the closest persistent memory NUMA node to satisfy the request, the allocation will fall back on other memory NUMA nodes.
 .BR Note:
-For this kind, the allocation will not succeed if two or more persistent memory NUMA nodes are in the same shortest distance to the same CPU.
+For this kind, the allocation will not succeed if two or more
+persistent memory NUMA nodes are in the same shortest distance to the same CPU on which process is eligible to run.
+Check on that eligibility is done upon starting the application.
 .PP
 All public member types and functions correspond to standard library allocator concepts and definitions. The current implementation supports C++11 standard.
 .PP

--- a/src/memkind_bandwidth.c
+++ b/src/memkind_bandwidth.c
@@ -273,7 +273,8 @@ static int bandwidth_set_closest_numanode(int num_unique,
                     VEC_PUSH_BACK(&node_arr[i], match.numanodes[j]);
                 }
             }
-            if (VEC_SIZE(&node_arr[i]) > 1 && is_single_node) {
+            if (VEC_SIZE(&node_arr[i]) > 1 && is_single_node &&
+                numa_bitmask_isbitset(numa_all_cpus_ptr, i)) {
                 log_err("Invalid Numa Configuration for cpu %d", i);
                 int node = -1;
                 VEC_FOREACH(node, &node_arr[i]) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
when process was limited to execute on specific CPUs (e.g. via taskset(1)
or numactl(8) cpunodebind/physcpubind option) check for invalid
configuration is limited to nodes assigned to these CPUs
It conflicts with #315 so I prefer to be merged after #315

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/316)
<!-- Reviewable:end -->
