### PR TITLE
Fix finding REGULAR nodes

### DIFF
--- a/src/memkind_regular.c
+++ b/src/memkind_regular.c
@@ -35,13 +35,12 @@ static void regular_nodes_init(void)
 {
     unsigned i;
     unsigned nodes_num = (unsigned)numa_num_configured_nodes();
-    int node = 0;
     struct bitmask *node_cpus = numa_allocate_cpumask();
 
     regular_nodes_mask = numa_allocate_nodemask();
 
     for (i = 0; i < nodes_num; i++) {
-        numa_node_to_cpus(node, node_cpus);
+        numa_node_to_cpus(i, node_cpus);
         if (numa_bitmask_weight(node_cpus))
             numa_bitmask_setbit(regular_nodes_mask, i);
     }


### PR DESCRIPTION
- check for get CPU of parsed NUMA nodes was always get it from Node 0

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/320)
<!-- Reviewable:end -->
