### PR TITLE
fix gcc-10 build failures

### DIFF
--- a/include/memkind_allocator.h
+++ b/include/memkind_allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Intel Corporation.
+ * Copyright (C) 2019 - 2020 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
 #include <exception>
 #include <type_traits>
 #include <cstddef>
+#include <stdexcept>
 
 #include "memkind.h"
 

--- a/include/pmem_allocator.h
+++ b/include/pmem_allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 - 2019 Intel Corporation.
+ * Copyright (C) 2018 - 2020 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,7 @@
 #include <type_traits>
 #include <atomic>
 #include <cstddef>
+#include <stdexcept>
 
 #include "memkind.h"
 

--- a/test/alloc_benchmark.c
+++ b/test/alloc_benchmark.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 - 2018 Intel Corporation.
+ * Copyright (C) 2016 - 2020 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,10 @@
 #define FREE_FN hbw_free
 #elif defined (TBBMALLOC)
 #include "tbbmalloc.h"
+void *(*scalable_malloc)(size_t);
+void *(*scalable_realloc)(void *, size_t);
+void *(*scalable_calloc)(size_t, size_t);
+void  (*scalable_free)(void *);
 #define MALLOC_FN scalable_malloc
 #define FREE_FN scalable_free
 #elif defined (PMEMMALLOC)

--- a/test/tbbmalloc.h
+++ b/test/tbbmalloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 - 2018 Intel Corporation.
+ * Copyright (C) 2016 - 2020 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,9 +25,9 @@
 #include <stdio.h>
 #include <dlfcn.h>
 
-void *(*scalable_malloc)(size_t);
-void *(*scalable_realloc)(void *, size_t);
-void *(*scalable_calloc)(size_t, size_t);
-void  (*scalable_free)(void *);
+extern void *(*scalable_malloc)(size_t);
+extern void *(*scalable_realloc)(void *, size_t);
+extern void *(*scalable_calloc)(size_t, size_t);
+extern void  (*scalable_free)(void *);
 
 int load_tbbmalloc_symbols();


### PR DESCRIPTION
Here's a couple of fixes that allow building memkind with GCC 10.

Despite that compiler being not released yet, Fedora [plans](https://fedoraproject.org/wiki/Changes/GCC10) to switch to it by their upcoming release.  And, we'd need to fix that sooner or later anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/338)
<!-- Reviewable:end -->
