### PR TITLE
Revert size calculation solution

### DIFF
--- a/include/memkind/internal/memkind_pmem.h
+++ b/include/memkind/internal/memkind_pmem.h
@@ -54,7 +54,6 @@ struct memkind_pmem {
     off_t offset;
     size_t max_size;
     pthread_mutex_t pmem_lock;
-    size_t current_size;
 };
 
 extern struct memkind_ops MEMKIND_PMEM_OPS;

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -846,7 +846,6 @@ MEMKIND_EXPORT int memkind_create_pmem(const char *dir, size_t max_size,
 
     priv->fd = fd;
     priv->offset = 0;
-    priv->current_size = 0;
     priv->max_size = max_size;
 
     return err;

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 - 2019 Intel Corporation.
+ * Copyright (C) 2015 - 2020 Intel Corporation.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -97,7 +97,10 @@ bool pmem_extent_dalloc(extent_hooks_t *extent_hooks,
                         bool committed,
                         unsigned arena_ind)
 {
-    // if madvise fail, it means that addr isn't mapped shared (doesn't come from pmem)
+    // pmem_extent_dalloc return true in case memory mapping associated with the extent
+    // remains mapped and is available for future use - it will be automatically retained
+    // for later reuse, false in case extent will be unmapped
+    // if madvise fail, it means that addr isn't mapped shared (MAP_SHARED is currently used only for pmem mapping)
     // and it should be unmapped to avoid space exhaustion when calling large number of
     // operations like memkind_create_pmem and memkind_destroy_kind
     errno = 0;
@@ -109,6 +112,7 @@ bool pmem_extent_dalloc(extent_hooks_t *extent_hooks,
         if (munmap(addr, size) == -1) {
             log_err("munmap failed!");
         }
+        return false;
     }
     return true;
 }

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -101,16 +101,7 @@ bool pmem_extent_dalloc(extent_hooks_t *extent_hooks,
     // and it should be unmapped to avoid space exhaustion when calling large number of
     // operations like memkind_create_pmem and memkind_destroy_kind
     errno = 0;
-    int status = madvise(addr, size, MADV_REMOVE);
-    if (!status) {
-        struct memkind *kind = get_kind_by_arena(arena_ind);
-        struct memkind_pmem *priv = kind->priv;
-        if (pthread_mutex_lock(&priv->pmem_lock) != 0)
-            assert(0 && "failed to acquire mutex");
-        priv->current_size -= size;
-        if (pthread_mutex_unlock(&priv->pmem_lock) != 0)
-            assert(0 && "failed to release mutex");
-    } else {
+    if (madvise(addr, size, MADV_REMOVE) != 0) {
         if (errno == EOPNOTSUPP) {
             log_fatal("Filesystem doesn't support FALLOC_FL_PUNCH_HOLE.");
             abort();
@@ -261,7 +252,7 @@ MEMKIND_EXPORT void *memkind_pmem_mmap(struct memkind *kind, void *addr,
     if (pthread_mutex_lock(&priv->pmem_lock) != 0)
         assert(0 && "failed to acquire mutex");
 
-    if (priv->max_size != 0 && priv->current_size + size > priv->max_size) {
+    if (priv->max_size != 0 && (size_t)priv->offset + size > priv->max_size) {
         if (pthread_mutex_unlock(&priv->pmem_lock) != 0)
             assert(0 && "failed to release mutex");
         return MAP_FAILED;
@@ -276,7 +267,6 @@ MEMKIND_EXPORT void *memkind_pmem_mmap(struct memkind *kind, void *addr,
     if ((result = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, priv->fd,
                        priv->offset)) != MAP_FAILED) {
         priv->offset += size;
-        priv->current_size += size;
     }
 
     if (pthread_mutex_unlock(&priv->pmem_lock) != 0)

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -75,7 +75,7 @@ static void pmem_get_size(struct memkind *kind, size_t &total, size_t &free)
     struct memkind_pmem *priv = reinterpret_cast<struct memkind_pmem *>(kind->priv);
 
     total = priv->max_size;
-    free = priv->max_size - priv->current_size; /* rough estimation */
+    free = priv->max_size - priv->offset; /* rough estimation */
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemPriv)


### PR DESCRIPTION
Solution introduced in ref #339 is wrong - with every calling extent_alloc and extent_dalloc we move offset of the file after mmap call. After some time with call malloc/free the posix_fallocate will return EFBIG error.
This PR revert the solution to the case were we track the current size of pool as an offset variable.

The scenario mentioned in #274 :
I allocated 99GB, and the priv->offset is at 99GB. Then I free 50GB space during which:
- madvise is called - actual physical space is deallocated

Then try to allocate 5GB it would succeeded:

- the future allocation would not call pmem_extent_alloc since the addresses will be reused according to jemalloc doc extent_dalloc_t "the virtual memory mapping associated with the extent remains mapped, in the same commit state, and available for future use, in which case it will be automatically retained for later reuse."

Ref #336 
Ref #274 
Ref 9aa70bd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/343)
<!-- Reviewable:end -->
