### PR TITLE
Extend config to specify minimum allocation alignment

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014 - 2019 Intel Corporation.
+#  Copyright (C) 2014 - 2020 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -500,7 +500,7 @@ static_lib: libmemkind.la
 	cp libmemkind.a .libs/
 	rm libmemkind.a
 
-JEMALLOC_CONFIG = --enable-autogen --without-export --with-version=5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756 \
+JEMALLOC_CONFIG = --enable-autogen @min_lg_align_opt@ --without-export --with-version=5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756 \
 			--disable-fill --disable-initial-exec-tls --with-jemalloc-prefix=@memkind_prefix@ \
 			--with-malloc-conf="narenas:@auto_arenas@,lg_tcache_max:@tcache_max_size_class@" \
 			#end

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014 - 2019 Intel Corporation.
+#  Copyright (C) 2014 - 2020 Intel Corporation.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -186,6 +186,17 @@ if test "$MEMKIND_PREFIX" != "" ; then
 fi
 
 AC_SUBST(memkind_prefix)
+
+#============================min_log_alignment=====================================
+min_lg_align_opt="";
+AC_ARG_VAR(MIN_LG_ALIGN,
+  [minimum allocation alignment (base 2 log) used in jemalloc, default value is architecture specific]
+)
+if test "$MIN_LG_ALIGN" != "" ; then
+  min_lg_align_opt=--with-lg-quantum=$MIN_LG_ALIGN;
+fi
+
+AC_SUBST(min_lg_align_opt)
 
 #===============================daxctl=========================================
 AC_ARG_ENABLE([daxctl],


### PR DESCRIPTION
- allow to modify lg_quantum paramter under jemalloc
- MIN_LG_ALIGN=3 ./configure command will result to specify minimum
allocation alignment to 8
- default value is architecture specific

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/345)
<!-- Reviewable:end -->
