### PR TITLE
Extend configure with --disable-heap-manager

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,22 @@ if test $daxctl_kmem = "yes" ; then
 fi
 AC_SUBST([enable_daxctl])
 
+#===============================heap manager=========================================
+AC_ARG_ENABLE([heap_manager],
+  [AS_HELP_STRING([--disable-heap-manager], [Use only default allocator: jemalloc])],
+[if test "x$enable_heap_manager" = "xno" ; then
+  enable_heap_manager="0"
+else
+  enable_heap_manager="1"
+fi
+],
+[enable_heap_manager="1"]
+)
+if test "x$enable_heap_manager" = "x1" ; then
+  AC_DEFINE([MEMKIND_ENABLE_HEAP_MANAGER], [], [Enable heap manager])
+fi
+AC_SUBST([enable_heap_manager])
+
 #============================cxx11=============================================
 
 AX_CXX_COMPILE_STDCXX_11([noext], [optional])

--- a/src/memkind_default.c
+++ b/src/memkind_default.c
@@ -240,5 +240,7 @@ MEMKIND_EXPORT int memkind_posix_check_alignment(struct memkind *kind,
 
 MEMKIND_EXPORT void memkind_default_init_once(void)
 {
+#ifdef MEMKIND_ENABLE_HEAP_MANAGER
     heap_manager_init(MEMKIND_DEFAULT);
+#endif
 }


### PR DESCRIPTION
- resign from environment variable would limit call stack for some functions
- after setting this only jemalloc could be used - MEMKIND_HEAP_MANAGER
environment variable will not have any effect

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/355)
<!-- Reviewable:end -->
