### PR TITLE
Add configure option memkind-initial-exec-tls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -523,7 +523,7 @@ static_lib: libmemkind.la
 	rm libmemkind.a
 
 JEMALLOC_CONFIG = --enable-autogen @min_lg_align_opt@ --without-export --with-version=5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756 \
-			@jemalloc_build_type_flags@ --disable-initial-exec-tls --with-jemalloc-prefix=@memkind_prefix@ \
+			@jemalloc_build_type_flags@  @memkind_initial_exec_tls@ --with-jemalloc-prefix=@memkind_prefix@ \
 			--with-malloc-conf="narenas:@auto_arenas@,lg_tcache_max:@tcache_max_size_class@" \
 			#end
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Copyright (C) 2014 - 2020 Intel Corporation.
+# Copyright (C) 2014 - 2021 Intel Corporation.
 
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
@@ -204,6 +204,23 @@ if test "$MIN_LG_ALIGN" != "" ; then
 fi
 
 AC_SUBST(min_lg_align_opt)
+
+#============================memkind-initial-exec-tls=====================================
+AC_ARG_ENABLE([memkind-initial-exec-tls],
+  [AS_HELP_STRING([--enable-memkind-initial-exec-tls], [Build library with initial-exec-tls support])],
+[if test "x$enable_memkind_initial_exec_tls" = "xno" ; then
+  enable_memkind_initial_exec_tls="0"
+else
+  enable_memkind_initial_exec_tls="1"
+fi
+],
+[enable_memkind_initial_exec_tls="0"]
+)
+if test "x$enable_memkind_initial_exec_tls" = "x0" ; then
+  memkind_initial_exec_tls=--disable-initial-exec-tls;
+fi
+
+AC_SUBST(memkind_initial_exec_tls)
 
 #===============================daxctl=========================================
 AC_ARG_ENABLE([daxctl],


### PR DESCRIPTION
- this allows to enable initial-exec-tls in jemalloc - optimize access
to thread local variable
- the option is not compatible with dlopen

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/362)
<!-- Reviewable:end -->
