### PR TITLE
Fix tests: destroy pmem kind and compare free memory space

### DIFF
--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -271,14 +271,14 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeMemoryAfterDestroyLargeClass)
 {
     memkind_t pmem_kind_test;
     struct statfs st;
-    double blocksAvailable;
+    double blocksInitial, blocksBeforeDestroy, blocksAfterDestroy;
 
     int err = memkind_create_pmem(PMEM_DIR, PMEM_PART_SIZE, &pmem_kind_test);
     ASSERT_EQ(0, err);
     ASSERT_NE(nullptr, pmem_kind_test);
 
     ASSERT_EQ(0, statfs(PMEM_DIR, &st));
-    blocksAvailable = st.f_bfree;
+    blocksInitial = st.f_bfree;
 
     while(1) {
         if (memkind_malloc(pmem_kind_test, 16 * KB) == nullptr)
@@ -286,40 +286,44 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeMemoryAfterDestroyLargeClass)
     }
 
     ASSERT_EQ(0, statfs(PMEM_DIR, &st));
-    ASSERT_GT(blocksAvailable, st.f_bfree);
+    blocksBeforeDestroy = st.f_bfree;
+    ASSERT_GT(blocksInitial, blocksBeforeDestroy);
 
     err = memkind_destroy_kind(pmem_kind_test);
     ASSERT_EQ(0, err);
 
     ASSERT_EQ(0, statfs(PMEM_DIR, &st));
-    ASSERT_NEAR(blocksAvailable, st.f_bfree, 1);
+    blocksAfterDestroy = st.f_bfree;
+    ASSERT_GT(blocksAfterDestroy, blocksBeforeDestroy);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemFreeMemoryAfterDestroySmallClass)
 {
     memkind_t pmem_kind_test;
     struct statfs st;
-    double blocksAvailable;
+    double blocksInitial, blocksBeforeDestroy, blocksAfterDestroy;
 
     int err = memkind_create_pmem(PMEM_DIR, PMEM_PART_SIZE, &pmem_kind_test);
     ASSERT_EQ(0, err);
     ASSERT_NE(nullptr, pmem_kind_test);
 
     ASSERT_EQ(0, statfs(PMEM_DIR, &st));
-    blocksAvailable = st.f_bfree;
+    blocksInitial = st.f_bfree;
 
     for(int i = 0; i < 100; ++i) {
         ASSERT_NE(memkind_malloc(pmem_kind_test, 32), nullptr);
     }
 
     ASSERT_EQ(0, statfs(PMEM_DIR, &st));
-    ASSERT_GT(blocksAvailable, st.f_bfree);
+    blocksBeforeDestroy = st.f_bfree;
+    ASSERT_GT(blocksInitial, blocksBeforeDestroy);
 
     err = memkind_destroy_kind(pmem_kind_test);
     ASSERT_EQ(0, err);
 
     ASSERT_EQ(0, statfs(PMEM_DIR, &st));
-    ASSERT_NEAR(blocksAvailable, st.f_bfree, 1);
+    blocksAfterDestroy = st.f_bfree;
+    ASSERT_GT(blocksAfterDestroy, blocksBeforeDestroy);
 }
 
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemRealloc)


### PR DESCRIPTION
- Stablize result by compare state before destroy kind and after

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/372)
<!-- Reviewable:end -->
