### PR TITLE
Extend memkind API by memkind_check_dax_path

### DIFF
--- a/examples/pmem_alignment.c
+++ b/examples/pmem_alignment.c
@@ -35,6 +35,13 @@ int main(int argc, char *argv[])
             "This example shows how to use memkind alignment and how it affects allocations.\nPMEM kind directory: %s\n",
             path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     err = memkind_create_pmem(path, PMEM_MAX_SIZE, &pmem_kind);
     if (err) {
         print_err_message(err);

--- a/examples/pmem_and_dax_kmem_kind.c
+++ b/examples/pmem_and_dax_kmem_kind.c
@@ -40,6 +40,13 @@ int main(int argc, char *argv[])
             "and persistent memory NUMA node (MEMKIND_DAX_KMEM).\nPMEM kind directory: %s\n",
             path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     err = memkind_create_pmem(path, 0, &pmem_kind);
     if (err) {
         print_err_message(err);

--- a/examples/pmem_and_default_kind.c
+++ b/examples/pmem_and_default_kind.c
@@ -55,6 +55,13 @@ int main(int argc, char *argv[])
             "This example shows how to allocate memory using standard memory (MEMKIND_DEFAULT) "
             "and file-backed kind of memory (PMEM).\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     err = memkind_create_pmem(path, 0, &pmem_kind);
     if (err) {
         print_err_message(err);

--- a/examples/pmem_config.c
+++ b/examples/pmem_config.c
@@ -46,6 +46,12 @@ int main(int argc, char *argv[])
     memkind_config_set_memory_usage_policy(test_cfg,
                                            MEMKIND_MEM_USAGE_POLICY_CONSERVATIVE);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
 
     // Create PMEM partition with specific configuration
     err =  memkind_create_pmem_with_config(test_cfg, &pmem_kind);

--- a/examples/pmem_cpp_allocator.cpp
+++ b/examples/pmem_cpp_allocator.cpp
@@ -129,6 +129,12 @@ int main(int argc, char *argv[])
             fprintf(stderr,"%s : Invalid path to pmem kind directory\n", argv[1]);
             return 1;
         }
+        int status = memkind_check_dax_path(argv[1]);
+        if (!status) {
+            std::cout << "PMEM kind %s is on DAX-enabled File system.\n" << std::endl;
+        } else {
+            std::cout << "PMEM kind %s is not on DAX-enabled File system.\n" << std::endl;
+        }
         pmem_directory = argv[1];
     }
 

--- a/examples/pmem_detect_kind.c
+++ b/examples/pmem_detect_kind.c
@@ -93,6 +93,13 @@ int main(int argc, char *argv[])
             "This example shows how to distinguish allocation from different kinds using detect kind function"
             "\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     err = memkind_create_pmem(path, 0, &pmem_kind);
     if (err) {
         print_err_message(err);

--- a/examples/pmem_free_with_unknown_kind.c
+++ b/examples/pmem_free_with_unknown_kind.c
@@ -37,6 +37,13 @@ int main(int argc, char **argv)
     fprintf(stdout,
             "This example shows how to use memkind_free with unknown kind as a parameter.\n");
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     err = memkind_create_pmem(path, PMEM_PART_SIZE, &pmem_kind);
     if (err) {
         print_err_message(err);

--- a/examples/pmem_kinds.c
+++ b/examples/pmem_kinds.c
@@ -39,6 +39,13 @@ int main(int argc, char *argv[])
             "This example shows how to create and destroy pmem kind with defined or unlimited size."
             "\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     // Create first PMEM partition with specific size
     err = memkind_create_pmem(path, PMEM_MAX_SIZE, &pmem_kind);
     if (err) {

--- a/examples/pmem_malloc.c
+++ b/examples/pmem_malloc.c
@@ -35,6 +35,13 @@ int main(int argc, char *argv[])
             "This example shows how to allocate memory and possibility to exceed pmem kind size."
             "\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     // Create PMEM partition with specific size
     err = memkind_create_pmem(path, PMEM_MAX_SIZE, &pmem_kind);
     if (err) {

--- a/examples/pmem_malloc_unlimited.c
+++ b/examples/pmem_malloc_unlimited.c
@@ -33,6 +33,13 @@ int main(int argc, char *argv[])
             "This example shows how to allocate memory with unlimited kind size."
             "\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     // Create PMEM partition with unlimited size
     err = memkind_create_pmem(path, 0, &pmem_kind_unlimited);
     if (err) {

--- a/examples/pmem_multithreads.c
+++ b/examples/pmem_multithreads.c
@@ -86,6 +86,13 @@ void *thread_ind(void *arg)
         return NULL;
     }
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled File system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled File system.\n", path);
+    }
+
     int err = memkind_create_pmem(path, PMEM_MAX_SIZE, &pmem_kind);
     if (err) {
         print_err_message(err);

--- a/examples/pmem_multithreads_onekind.c
+++ b/examples/pmem_multithreads_onekind.c
@@ -48,6 +48,13 @@ int main(int argc, char *argv[])
             "This example shows how to use multithreading with one main pmem kind."
             "\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     // Create PMEM partition with unlimited size
     err = memkind_create_pmem(path, 0, &pmem_kind_unlimited);
     if (err) {

--- a/examples/pmem_usable_size.c
+++ b/examples/pmem_usable_size.c
@@ -35,6 +35,13 @@ int main(int argc, char *argv[])
             "This example shows difference between the expected and the actual allocation size."
             "\nPMEM kind directory: %s\n", path);
 
+    int status = memkind_check_dax_path(path);
+    if (!status) {
+        fprintf(stdout, "PMEM kind %s is on DAX-enabled file system.\n", path);
+    } else {
+        fprintf(stdout, "PMEM kind %s is not on DAX-enabled file system.\n", path);
+    }
+
     err = memkind_create_pmem(path, 0, &pmem_kind_unlimited);
     if (err) {
         print_err_message(err);

--- a/include/memkind.h
+++ b/include/memkind.h
@@ -407,6 +407,14 @@ void memkind_free(memkind_t kind, void *ptr);
 ///
 void *memkind_defrag_reallocate(memkind_t kind, void *ptr);
 
+///
+/// \brief Verifies if file-backed memory kind in the specified directory can be created with the DAX attribute
+/// \note STANDARD API
+/// \param path path to specified directory for PMEM kind
+/// \return Memkind operation status, MEMKIND_SUCCESS on success, other values on failure
+///
+int memkind_check_dax_path(const char *pmem_dir);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/memkind/internal/memkind_pmem.h
+++ b/include/memkind/internal/memkind_pmem.h
@@ -28,6 +28,7 @@ int memkind_pmem_destroy(struct memkind *kind);
 void *memkind_pmem_mmap(struct memkind *kind, void *addr, size_t size);
 int memkind_pmem_get_mmap_flags(struct memkind *kind, int *flags);
 int memkind_pmem_create_tmpfile(const char *dir, int *fd);
+int memkind_pmem_validate_dir(const char *dir);
 
 struct memkind_pmem {
     int fd;

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -69,6 +69,8 @@ This header expose STANDARD and EXPERIMENTAL API. API Standards are described be
 .BI "int memkind_destroy_kind(memkind_t " "kind" );
 .br
 .BI "int memkind_check_available(memkind_t " "kind" );
+.br
+.BI "int memkind_check_dax_path(const char " "*pmem_dir" );
 .sp
 .B "STATISTICS:"
 .br
@@ -542,6 +544,13 @@ all allocated memory will be freed after kind will be destroyed.
 returns zero if the specified
 .I kind
 is available or an error code from the
+.B ERRORS
+section if it is not.
+.PP
+.BR memkind_check_dax_path ()
+retruns zero if file-backed kind memory in the specified directory path
+.I pmem_dir
+can be created with the DAX attribute or an error code from the
 .B ERRORS
 section if it is not.
 .PP

--- a/man/memkind_pmem.3
+++ b/man/memkind_pmem.3
@@ -17,6 +17,8 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .br
 .BI "int memkind_pmem_get_mmap_flags(struct memkind " "*kind" ", int " "*flags" );
 .br
+.BI "int memkind_pmem_validate_dir(const char " "*dir" );
+.br
 .SH DESCRIPTION
 .PP
 The pmem memory memkind operations enable memory kinds built on memory-mapped
@@ -31,14 +33,12 @@ attributes, depending on the file system containing the memory-mapped files.
 (See also
 .IR http://pmem.io/pmdk/libvmem ).
 .PP
-The pmem memkinds are most useful when used with
-.I Direct Access
-storage (DAX), which is memory-addressable persistent storage
-that supports load/store access without being paged via the system page cache.
+The pmem kinds are most useful when used with DAX (direct mapping of persistent memory), which is memory-addressable
+persistent storage that supports load/store access without being paged via the system page cache.
 A Persistent Memory-aware file system is typically used to provide this
 type of access.
 .PP
-The most convenient way to create pmem memkinds is to use
+The most convenient way to create pmem kinds is to use
 .BR memkind_create_pmem ()
 or
 .BR memkind_create_pmem_with_config ()
@@ -77,6 +77,14 @@ to
 See
 .BR mmap (2)
 for more information about these flags.
+.PP
+.BR memkind_pmem_validate_dir ()
+returns zero if file created in specified
+.I pmem_dir
+supports DAX (direct mapping of persistent memory) or an error code from the
+.B ERRORS
+if
+not.
 .TP
 .B MEMKIND_PMEM_CHUNK_SIZE
 The size of the PMEM chunk size.

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -894,3 +894,8 @@ MEMKIND_EXPORT int memkind_get_stat(memkind_t kind, memkind_stat_type stat,
         return kind->ops->get_stat(kind, stat, value);
     }
 }
+
+MEMKIND_EXPORT int memkind_check_dax_path(const char *pmem_dir)
+{
+    return memkind_pmem_validate_dir(pmem_dir);
+}

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -13,6 +13,15 @@
 #include <assert.h>
 #include <signal.h>
 #include <string.h>
+
+#ifndef MAP_SYNC
+#define MAP_SYNC 0x80000
+#endif
+
+#ifndef MAP_SHARED_VALIDATE
+#define MAP_SHARED_VALIDATE 0x03
+#endif
+
 MEMKIND_EXPORT struct memkind_ops MEMKIND_PMEM_OPS = {
     .create = memkind_pmem_create,
     .destroy = memkind_pmem_destroy,
@@ -347,4 +356,34 @@ MEMKIND_EXPORT int memkind_pmem_get_mmap_flags(struct memkind *kind, int *flags)
 {
     *flags = MAP_SHARED;
     return 0;
+}
+
+int memkind_pmem_validate_dir(const char *dir)
+{
+    int ret = MEMKIND_SUCCESS;
+    int fd = -1;
+    const size_t size = sysconf(_SC_PAGESIZE);
+
+    int err = memkind_pmem_create_tmpfile(dir, &fd);
+
+    if (err) {
+        return MEMKIND_ERROR_RUNTIME;
+    }
+
+    if (ftruncate(fd, size) != 0) {
+        ret = MEMKIND_ERROR_RUNTIME;
+        goto end;
+    }
+
+    void *addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                      MAP_SHARED_VALIDATE | MAP_SYNC, fd, 0);
+    if (addr == MAP_FAILED) {
+        ret = MEMKIND_ERROR_MMAP;
+        goto end;
+    }
+    munmap(addr, size);
+
+end:
+    (void)close(fd);
+    return ret;
 }

--- a/test/memkind_pmem_tests.cpp
+++ b/test/memkind_pmem_tests.cpp
@@ -86,6 +86,32 @@ TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCreatePmemFailNonExistingDirectory)
     ASSERT_EQ(ENOENT, errno);
 }
 
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCheckDaxNonExistingPath)
+{
+    const char *non_existing_directory = "/temp/non_exisitng_directory";
+    errno = 0;
+    int err = memkind_check_dax_path(non_existing_directory);
+    ASSERT_EQ(MEMKIND_ERROR_RUNTIME, err);
+    ASSERT_EQ(ENOENT, errno);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCheckDaxFailNonDaxPath)
+{
+    const char *non_dax_directory = "/tmp/";
+    errno = 0;
+    int err = memkind_check_dax_path(non_dax_directory);
+    ASSERT_EQ(MEMKIND_ERROR_MMAP, err);
+    ASSERT_EQ(EOPNOTSUPP, errno);
+}
+
+TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemCheckDaxSuccess)
+{
+    errno = 0;
+    int err = memkind_check_dax_path(PMEM_DIR);
+    ASSERT_EQ(MEMKIND_SUCCESS, err);
+    ASSERT_EQ(0, errno);
+}
+
 TEST_F(MemkindPmemTests, test_TC_MEMKIND_PmemMallocFragmentation)
 {
     const size_t size_array[] = {


### PR DESCRIPTION
Extend memkind API by provide function which tells if path leads to real PMEM device:

Ref:
https://github.com/memkind/memkind/issues/342#issuecomment-586965808
https://github.com/memkind/memkind/issues/107#issue-368318915

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/379)
<!-- Reviewable:end -->
