### PR TITLE
fix a gcc-11 warning in gtest

### DIFF
--- a/test/gtest_fused/gtest/gtest-all.cc
+++ b/test/gtest_fused/gtest/gtest-all.cc
@@ -7937,14 +7937,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
 // correct answer.
 void StackLowerThanAddress(const void* ptr, bool* result) GTEST_NO_INLINE_;
 void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy = 0;
   *result = (&dummy < ptr);
 }
 
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Patch found in Fedora packaging, by Jeff Law.

The code being patched looks old and musty, and is there only to detect hppa which is not going to be supported by memkind: 32-bit still kind of lives (but we require 64 bits), hppa64 has been dropped by all distributions, including Open/NetBSD.  Thus, it's all necrocomputing that could be cleaned away.

But, as gtest is outside code, let's pick Jeff Law's minimal patch instead of doing large changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/382)
<!-- Reviewable:end -->
