### PR TITLE
Change metadata allocation function:

### DIFF
--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -460,7 +460,7 @@ static inline int get_tcache_flag(unsigned partition, size_t size)
 
     unsigned *tcache_map = pthread_getspecific(tcache_key);
     if(tcache_map == NULL) {
-        tcache_map = calloc(MEMKIND_NUM_BASE_KIND, sizeof(unsigned));
+        tcache_map = jemk_calloc(MEMKIND_NUM_BASE_KIND, sizeof(unsigned));
         if(tcache_map == NULL) {
             return MALLOCX_TCACHE_NONE;
         }
@@ -662,7 +662,7 @@ MEMKIND_EXPORT int memkind_thread_get_arena(struct memkind *kind,
     arena_tsd = pthread_getspecific(kind->arena_key);
 
     if (MEMKIND_UNLIKELY(arena_tsd == NULL)) {
-        arena_tsd = malloc(sizeof(unsigned int));
+        arena_tsd = jemk_malloc(sizeof(unsigned int));
         if (arena_tsd == NULL) {
             err = MEMKIND_ERROR_MALLOC;
             log_err("malloc() failed.");


### PR DESCRIPTION
Change glibc memory management function to malloc/calloc call to jemalloc variant
to avoid recursive call in case of:
  * LD_PRELOAD mechanism
  * multithreaded allocation
  * usage of the static kind like e.g. MEMKIND_DAX_KMEM

Ref #381 
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/385)
<!-- Reviewable:end -->
