### PR TITLE
Increase PMEM performance tests operations count

### DIFF
--- a/test/pmem_alloc_performance_tests.cpp
+++ b/test/pmem_alloc_performance_tests.cpp
@@ -196,7 +196,7 @@ TEST_F(PmemAllocPerformanceTest,
        test_TC_MEMKIND_MEMKIND_PMEM_malloc_72_thread_1572864_bytes)
 {
     run_test(AllocatorTypes::MEMKIND_PMEM, FunctionCalls::MALLOC, 72, 1572864,
-             1000);
+             10000);
 }
 
 TEST_F(PmemAllocPerformanceTest,
@@ -300,7 +300,7 @@ TEST_F(PmemAllocPerformanceTest,
        test_TC_MEMKIND_MEMKIND_PMEM_calloc_72_thread_1572864_bytes)
 {
     run_test(AllocatorTypes::MEMKIND_PMEM, FunctionCalls::CALLOC, 72, 1572864,
-             1000);
+             10000);
 }
 
 TEST_F(PmemAllocPerformanceTest,
@@ -405,5 +405,5 @@ TEST_F(PmemAllocPerformanceTest,
        test_TC_MEMKIND_MEMKIND_PMEM_realloc_72_thread_1572864_bytes)
 {
     run_test(AllocatorTypes::MEMKIND_PMEM, FunctionCalls::REALLOC, 72, 1572864,
-             1000);
+             10000);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase mem_operations_num parameter of some PMEM performance tests to conform with parameters in HBW performance tests.
### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/391)
<!-- Reviewable:end -->
