### PR TITLE
Remove HBW Memory requirement from MEMKIND_HUGETLB

### DIFF
--- a/README
+++ b/README
@@ -136,7 +136,7 @@ which are using the memkind library for dynamic linking at run time:
 | Memory kind                   | NUMA  |  HBW Memory | Hugepages | Device DAX | Filesystem supporting hole punching |
 | ----------------------------- |:-----:|:-----------:|:---------:|:----------:|:-----------------------------------:|
 | MEMKIND_DEFAULT               |       |             |           |            |                                     |
-| MEMKIND_HUGETLB               | X     | X           | X         |            |                                     |
+| MEMKIND_HUGETLB               | X     |             | X         |            |                                     |
 | MEMKIND_HBW                   | X     | X           |           |            |                                     |
 | MEMKIND_HBW_ALL               | X     | X           |           |            |                                     |
 | MEMKIND_HBW_HUGETLB           | X     | X           | X         |            |                                     |


### PR DESCRIPTION
- MEMKIND_HUGETLB don't need HBW memory to work correctly

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/396)
<!-- Reviewable:end -->
