### PR TITLE
Added a way to identify HBW node using hwloc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Michal Biesek <michal.biesek@intel.com>
 Adam Borowski <adam.borowski@intel.com>
 Yuan Zhou <yuan.zhou@intel.com>
 Harald Servat <harald.servat@intel.com>
+Keiya Nobuta <nobuta.keiya@fujitsu.com>

--- a/README
+++ b/README
@@ -35,10 +35,11 @@ features.  Memkind interface allows to create and control file-backed memory
 9. [Setting Logging Mechanism](#setting-logging-mechanism)
 10. [Setting Heap Manager](#setting-heap-manager)
 11. [Simulating High Bandwidth Memory](#simulating-high-bandwidth-memory)
-12. [Projects](#projects)
-13. [Testing](#testing)
-14. [Notes](#notes)
-15. [Disclaimer](#disclaimer)
+12. [Identification of High Bandwidth Memory](#identification-of-high-bandwidth-memory)
+13. [Projects](#projects)
+14. [Testing](#testing)
+15. [Notes](#notes)
+16. [Disclaimer](#disclaimer)
 
 ## Interfaces
 The memkind library delivers four interfaces:
@@ -312,6 +313,15 @@ node 1.  The --cpunodebind=0 option to numactl will bind the process
 threads to CPUs associated with NUMA node 0.  With this configuration
 standard allocations will be fetched across the QPI bus, and high
 bandwidth allocations will be local to the process CPU.
+
+## Identification of High Bandwidth Memory
+High bandwidth memory are identified using hwloc if available. The default
+threshold for identifying high bandwidth memory is 200 GB/s, you can change the
+threshold using the MEMKIND_HBW_THRESHOLD environment variable.
+
+MEMKIND_HBW_THRESHOLD is in MB/s. For example, to set to 100 GB/s:
+
+    export MEMKIND_HBW_THRESHOLD=102400.
 
 ## Projects
 The following software use memkind library:

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -971,6 +971,11 @@ for parsing, so the syntax described in the
 .BR numa (3)
 man page for this routine applies: e.g. 1-3,5 is a valid setting.
 .TP
+.B MEMKIND_HBW_THRESHOLD
+This environment variable is bandwidth in MB/s that is the threshold for
+identifying high bandwidth memory. The default threshold is 204800 (200 GB/s),
+which is used if this environment is not set.
+.TP
 .B MEMKIND_DAX_KMEM_NODES
 This environment variable is a comma-separated list of NUMA nodes that
 are treated as PMEM memory. Uses the

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -24,6 +24,12 @@
 #include <sched.h>
 #include <stdint.h>
 #include <assert.h>
+#include "config.h"
+#ifdef MEMKIND_HWLOC
+#include <hwloc.h>
+
+#define MEMKIND_HBW_THRESHOLD_DEFAULT (200 * 1024) // Default threshold is 200 GB/s
+#endif
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_OPS = {
     .create = memkind_arena_create,
@@ -281,7 +287,7 @@ static cpu_model_data_t get_cpu_model_data()
     return data;
 }
 
-static bool is_hbm_supported(cpu_model_data_t cpu)
+static bool is_hbm_legacy_supported(cpu_model_data_t cpu)
 {
     return cpu.family == CPU_FAMILY_INTEL &&
            (cpu.model == CPU_MODEL_KNL || cpu.model == CPU_MODEL_KNM);
@@ -315,29 +321,106 @@ static int get_high_bandwidth_nodes(struct bitmask *hbw_node_mask)
     return MEMKIND_ERROR_UNAVAILABLE;
 }
 
-///This function tries to fill bandwidth array based on knowledge about known CPU models
-static int fill_bandwidth_values_heuristically(int *bandwidth)
+static int get_high_bandwidth_nodes_hmat(struct bitmask *hbw_node_mask)
 {
-    cpu_model_data_t cpu = get_cpu_model_data();
+#ifdef MEMKIND_HWLOC
+    const char *hbw_threshold_env = secure_getenv("MEMKIND_HBW_THRESHOLD"); // replace secure_getenv with memkind_get_env
+    size_t hbw_threshold;
+    int err;
+    hwloc_topology_t topology;
+    hwloc_obj_t init_node = NULL;
 
-    if(!is_hbm_supported(cpu)) {
-        log_err("High Bandwidth Memory is not supported by this CPU.");
+    if (hbw_threshold_env) {
+        log_info("Environment variable MEMKIND_HBW_THRESHOLD detected: %s.",
+                 hbw_threshold_env);
+        int ret = sscanf(hbw_threshold_env, "%zud", &hbw_threshold);
+        if (ret == 0) {
+            log_err("Environment variable MEMKIND_HBW_THRESHOLD is invalid value.");
+            return MEMKIND_ERROR_ENVIRON;
+        }
+    } else {
+        hbw_threshold = MEMKIND_HBW_THRESHOLD_DEFAULT;
+    }
+
+    err = hwloc_topology_init(&topology);
+    if (err) {
+        log_err("hwloc initialize failed");
         return MEMKIND_ERROR_UNAVAILABLE;
     }
 
-    switch(cpu.model) {
-        case CPU_MODEL_KNL:
-        case CPU_MODEL_KNM: {
-            int ret = bandwidth_fill(bandwidth, get_high_bandwidth_nodes);
-            if(ret == 0) {
-                log_info("Detected High Bandwidth Memory.");
-            }
-            return ret;
-        }
-        default:
-            return MEMKIND_ERROR_UNAVAILABLE;
+    err = hwloc_topology_load(topology);
+    if (err) {
+        log_err("hwloc topology load failed");
+        hwloc_topology_destroy(topology);
+        return MEMKIND_ERROR_UNAVAILABLE;
     }
+
+    struct bitmask *node_cpus = numa_allocate_cpumask();
+    while ((init_node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE,
+                                                   init_node)) != NULL) {
+        struct hwloc_location initiator;
+        hwloc_obj_t target = NULL;
+
+        numa_node_to_cpus(init_node->os_index, node_cpus);
+        if (numa_bitmask_weight(node_cpus) == 0) {
+            log_info("Node skipped %d - no CPU detected in initiator Node.",
+                     init_node->os_index);
+            continue;
+        }
+
+        initiator.type = HWLOC_LOCATION_TYPE_CPUSET;
+        initiator.location.cpuset = init_node->cpuset;
+
+        while ((target = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE,
+                                                    target)) != NULL) {
+            hwloc_uint64_t bandwidth;
+            err = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_BANDWIDTH, target,
+                                          &initiator, 0, &bandwidth);
+            if (err) {
+                log_info("Node skipped - cannot read initiator Node %d and target Node %d.",
+                         init_node->os_index, target->os_index);
+                continue;
+            }
+
+            if (bandwidth >= hbw_threshold) {
+                numa_bitmask_setbit(hbw_node_mask, target->os_index);
+            }
+        }
+    }
+
+    numa_bitmask_free(node_cpus);
+    hwloc_topology_destroy(topology);
+    if (numa_bitmask_weight(hbw_node_mask) == 0) {
+        return MEMKIND_ERROR_UNAVAILABLE;
+    }
+
+    return 0;
+#else
+    log_err("High Bandwidth NUMA nodes cannot be automatically detected.");
+    return MEMKIND_ERROR_OPERATION_FAILED;
+#endif
 }
+
+///This function tries to fill bandwidth array based on knowledge about known CPU models
+static int fill_bandwidth_values_heuristically(int *bandwidth)
+{
+    int ret;
+    cpu_model_data_t cpu = get_cpu_model_data();
+
+    if(is_hbm_legacy_supported(cpu)) {
+        ret = bandwidth_fill(bandwidth, get_high_bandwidth_nodes);
+    } else {
+        ret = bandwidth_fill(bandwidth, get_high_bandwidth_nodes_hmat);
+    }
+
+    if(ret != 0) {
+        return MEMKIND_ERROR_UNAVAILABLE;
+    }
+
+    log_info("Detected High Bandwidth Memory.");
+    return ret;
+}
+
 static void memkind_hbw_closest_numanode_init(void)
 {
     struct hbw_closest_numanode_t *g = &memkind_hbw_closest_numanode_g;


### PR DESCRIPTION
This patch adds the ability to identify HBW nodes using information
obtained from ACPI HMAT table via hwloc if available.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->
I tested in the same environment as issue #383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/401)
<!-- Reviewable:end -->
