### PR TITLE
fix missing kinds::HIGHEST_CAPACITY in interface memkind_allocator.h

### DIFF
--- a/include/memkind_allocator.h
+++ b/include/memkind_allocator.h
@@ -40,6 +40,7 @@ namespace libmemkind
         DAX_KMEM = 11,
         DAX_KMEM_ALL = 12,
         DAX_KMEM_PREFERRED = 13,
+        HIGHEST_CAPACITY = 14,
     };
 
     namespace static_kind
@@ -119,6 +120,9 @@ namespace libmemkind
                         break;
                     case libmemkind::kinds::DAX_KMEM_PREFERRED:
                         _kind = MEMKIND_DAX_KMEM_PREFERRED;
+                        break;
+                    case libmemkind::kinds::HIGHEST_CAPACITY:
+                        _kind = MEMKIND_HIGHEST_CAPACITY;
                         break;
                     default:
                         throw std::runtime_error("Unknown libmemkind::kinds");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/419)
<!-- Reviewable:end -->
