### PR TITLE
Add missing header for memkind_get_env

### DIFF
--- a/src/memkind_mem_attributes.c
+++ b/src/memkind_mem_attributes.c
@@ -3,6 +3,7 @@
 
 #include <memkind/internal/memkind_mem_attributes.h>
 #include <memkind/internal/memkind_log.h>
+#include <memkind/internal/memkind_private.h>
 
 #include "config.h"
 #ifdef MEMKIND_HWLOC


### PR DESCRIPTION
- fix 1b43410

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/445)
<!-- Reviewable:end -->
