### PR TITLE
Add generic mechanism for HMAT tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -523,6 +523,7 @@ test/memkind_defrag_reallocate.cpp
 test/memkind_versioning_tests.cpp
 test/memory_footprint_test.cpp
 test/memory_manager.h
+test/memory_topology.h
 test/multithreaded_tests.cpp
 test/negative_tests.cpp
 test/performance/framework.cpp

--- a/copying_headers/MANIFEST.freeBSD
+++ b/copying_headers/MANIFEST.freeBSD
@@ -165,6 +165,7 @@ test/memkind_stat_test.cpp
 test/memkind_versioning_tests.cpp
 test/memory_footprint_test.cpp
 test/memory_manager.h
+test/memory_topology.h
 test/multithreaded_tests.cpp
 test/negative_tests.cpp
 test/performance/framework.cpp

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Copyright (C) 2014 - 2020 Intel Corporation.
+# Copyright (C) 2014 - 2021 Intel Corporation.
 
 AM_CPPFLAGS += -Itest/gtest_fused -DMEMKIND_DEPRECATED\(x\)=x
 
@@ -64,10 +64,11 @@ test_pmem_test_SOURCES = $(fused_gtest) test/memkind_pmem_config_tests.cpp test/
 test_pmem_test_LDADD = libmemkind.la
 test_memkind_highcapacity_test_SOURCES = $(fused_gtest) test/memkind_highcapacity_tests.cpp
 test_memkind_highcapacity_test_LDADD = libmemkind.la
-test_hmat_test_SOURCES = $(fused_gtest) test/memkind_hmat_tests.cpp
+test_hmat_test_SOURCES = $(fused_gtest) test/memkind_hmat_tests.cpp test/memory_topology.h
 test_hmat_test_LDADD = libmemkind.la
 test_defrag_reallocate_SOURCES = $(fused_gtest) test/memkind_defrag_reallocate.cpp
 test_defrag_reallocate_LDADD = libmemkind.la
+test_hmat_test_CXXFLAGS = $(AM_CXXFLAGS) $(CXXFLAGS) $(OPENMP_CFLAGS)
 endif
 
 fused_gtest = test/gtest_fused/gtest/gtest-all.cc \

--- a/test/memkind_hmat_tests.cpp
+++ b/test/memkind_hmat_tests.cpp
@@ -1,26 +1,89 @@
 // SPDX-License-Identifier: BSD-2-Clause
-/* Copyright (C) 2020 Intel Corporation. */
+/* Copyright (C) 2020 - 2021 Intel Corporation. */
 
 #include <memkind.h>
+#include <memory>
+#include <numa.h>
+#include <numaif.h>
+#include <omp.h>
+#include <sys/sysinfo.h>
+#include <unordered_map>
 
 #include "common.h"
+#include "memory_topology.h"
 
-class MemkindHMATFunctionalTests: public ::testing::Test
+using TpgPtr = std::unique_ptr<AbstractTopology>;
+using MemoryTpg = std::pair<std::string, TpgPtr>;
+using MapMemoryTpg =
+    std::unordered_map<MemoryTpg::first_type, MemoryTpg::second_type>;
+
+static MapMemoryTpg TopologyMap;
+
+class MemkindHMATFunctionalTestsParam: public ::testing::Test,
+    public ::testing::WithParamInterface<memkind_t>
 {
 protected:
+    memkind_t memory_kind;
+    const char *memory_tpg;
 
     void SetUp()
-    {}
+    {
+        memory_kind = GetParam();
+        memory_tpg = std::getenv("MEMKIND_TEST_TOPOLOGY");
+        if (memory_tpg == nullptr)
+            GTEST_SKIP() << "This test requires MEMKIND_TEST_TOPOLOGY";
+        // TODO try use Setup for whole Suite
+        if (TopologyMap.size() == 0) {
+            //TODO find better way to lookup for number of classes
+            TopologyMap.reserve(5);
+            TopologyMap.emplace(MemoryTpg("KnightsMillAll2All", TpgPtr(new KNM_All2All)));
+            TopologyMap.emplace(MemoryTpg("KnightsMillSNC2", TpgPtr(new KNM_SNC2)));
+            TopologyMap.emplace(MemoryTpg("KnightsMillSNC4", TpgPtr(new KNM_SNC4)));
+            TopologyMap.emplace(MemoryTpg("CascadeLake2Var1", TpgPtr(new CLX_2_var1)));
+            TopologyMap.emplace(MemoryTpg("CascadeLake4Var1", TpgPtr(new CLX_4_var1)));
+            std::cout << "MEMKIND_TEST_TOPOLOGY is: " << memory_tpg << std::endl;
+        }
+    }
 
     void TearDown()
     {}
 };
 
-TEST_F(MemkindHMATFunctionalTests, test_TC_HMAT_example)
+INSTANTIATE_TEST_CASE_P(
+    KindParam, MemkindHMATFunctionalTestsParam,
+    ::testing::Values(MEMKIND_HBW));
+
+TEST_P(MemkindHMATFunctionalTestsParam,
+       test_tc_memkind_HMAT_verify_InitTargetNode)
 {
-    if(const char *env_p = std::getenv("MEMKIND_TEST_TOPOLOGY")) {
-        std::cout << "MEMKIND_TEST_TOPOLOGY is: " << env_p << '\n';
-    } else {
-        std::cout << "MEMKIND_TEST_TOPOLOGY was not presetnt:" << '\n';
+    int status = numa_available();
+    ASSERT_EQ(status, 0);
+    const size_t size = 4099;
+    int threads_num = get_nprocs();
+    auto &topology = TopologyMap.at(memory_tpg);
+    #pragma omp parallel for num_threads(threads_num)
+    for(int thread_id=0; thread_id<threads_num; ++thread_id) {
+        cpu_set_t cpu_set;
+        CPU_ZERO(&cpu_set);
+        CPU_SET(thread_id, &cpu_set);
+        int status = sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set);
+        int cpu = sched_getcpu();
+        EXPECT_EQ(thread_id, cpu);
+        void *ptr = memkind_malloc(memory_kind, size);
+        if (topology->is_kind_supported(memory_kind)) {
+            EXPECT_TRUE(ptr != nullptr);
+            memset(ptr, 0, size);
+            int init_node = numa_node_of_cpu(cpu);
+            EXPECT_NE(-1, init_node);
+            int target_node = -1;
+            status = get_mempolicy(&target_node, nullptr, 0, ptr,
+                                   MPOL_F_NODE | MPOL_F_ADDR);
+            EXPECT_EQ(0, status);
+            auto res = topology->verify_kind(memory_kind, {init_node, target_node});
+            EXPECT_EQ(true, res);
+            memkind_free(memory_kind, ptr);
+        } else {
+            EXPECT_TRUE(ptr == nullptr);
+        }
     }
 }

--- a/test/memory_topology.h
+++ b/test/memory_topology.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/* Copyright (C) 2021 Intel Corporation. */
+
+#pragma once
+
+#include <memkind.h>
+
+#include <iostream>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+
+struct Nodes {
+    int init;
+    int target;
+};
+using NodeSet = std::pair<int, std::unordered_set<int>>;
+using MapNodeSet = std::unordered_map<int, std::unordered_set<int>>;
+
+class AbstractTopology
+{
+private:
+    virtual MapNodeSet HBW_nodes() const
+    {
+        return {};
+    }
+    bool test_node_set(const Nodes &nodes, const MapNodeSet &map_nodes) const
+    {
+        auto init_node_tpg = map_nodes.find(nodes.init);
+
+        if (init_node_tpg != map_nodes.end()) {
+            auto target_nodes_tpg = init_node_tpg->second;
+            auto found_node = target_nodes_tpg.find(nodes.target);
+
+            if (found_node != target_nodes_tpg.end()) {
+                return true;
+            }
+        }
+        std::cout << "Failed for, Init: " << nodes.init << "Target: " << nodes.target <<
+                  std::endl;
+        return false;
+    }
+public:
+    bool is_kind_supported(memkind_t memory_kind) const
+    {
+        if (memory_kind == MEMKIND_HBW)
+            return (HBW_nodes().size() > 0);
+        return false;
+    }
+
+    bool verify_kind(memkind_t memory_kind, const Nodes &nodes) const
+    {
+        if (memory_kind == MEMKIND_HBW)
+            return test_node_set(nodes, HBW_nodes());
+        return false;
+    }
+    virtual ~AbstractTopology() = default;
+};
+
+class KNM_All2All : public AbstractTopology
+{
+private:
+    MapNodeSet HBW_nodes() const final
+    {
+        MapNodeSet nodeset_map;
+        nodeset_map.emplace(NodeSet(0, {1}));
+        return nodeset_map;
+    }
+};
+
+class KNM_SNC2 : public AbstractTopology
+{
+private:
+    MapNodeSet HBW_nodes() const final
+    {
+        MapNodeSet nodeset_map;
+        nodeset_map.emplace(NodeSet(0, {2}));
+        nodeset_map.emplace(NodeSet(1, {3}));
+        return nodeset_map;
+    }
+};
+
+class KNM_SNC4 : public AbstractTopology
+{
+private:
+    MapNodeSet HBW_nodes() const final
+    {
+        MapNodeSet nodeset_map;
+        nodeset_map.emplace(NodeSet(0, {4}));
+        nodeset_map.emplace(NodeSet(1, {5}));
+        nodeset_map.emplace(NodeSet(2, {6}));
+        nodeset_map.emplace(NodeSet(3, {7}));
+        return nodeset_map;
+    }
+};
+
+class CLX_2_var1 : public AbstractTopology
+{};
+
+class CLX_4_var1 : public AbstractTopology
+{};


### PR DESCRIPTION
- add test to verify mapping between initiator Node and target Node
- ~limit the cpu dedicated for initiator NUMA Node to easily iterate
over all and retrieve always new chunk~
-  use multithreaded version to switch CPU and use different arena - see:
    memkind_thread_get_arena implementation



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/448)
<!-- Reviewable:end -->
