### PR TITLE
Fix memory matrix calculate

### DIFF
--- a/utils/memory_matrix/memory_matrix.c
+++ b/utils/memory_matrix/memory_matrix.c
@@ -8,116 +8,101 @@
 #include "hwloc.h"
 #include "numa.h"
 
-static struct bitmask *node_mask;
+static struct bitmask *node_cpumask;
+static hwloc_topology_t topology;
 
-static void print_array(const int *array_to_print, const char *header)
+static void print_attr(hwloc_memattr_id_t mem_attr)
 {
-    int num_nodes = numa_num_configured_nodes();
-    int i = 0;
-    int j = 0;
-    printf("%s\n",header);
+    int max_node_id = numa_max_node();
+    int init_id, target_id;
+
+    if (mem_attr == HWLOC_MEMATTR_ID_BANDWIDTH) {
+        printf("Node bandwidth [MiB/s]:\n");
+    } else if (mem_attr == HWLOC_MEMATTR_ID_LATENCY) {
+        printf("Node latency [ns]:\n");
+    } else {
+        printf("[ERROR] Unknown memory attribute\n");
+        numa_free_cpumask(node_cpumask);
+        hwloc_topology_destroy(topology);
+        exit(-1);
+    }
+
     printf("node");
-    for (i=0; i<=node_mask->size; ++i) {
-        if (numa_bitmask_isbitset(node_mask, i)) {
-            printf("%6d ", i);
+    for (init_id=0; init_id<=max_node_id; ++init_id) {
+        if (numa_bitmask_isbitset(numa_all_nodes_ptr, init_id)) {
+            printf("%6d ", init_id);
         }
     }
     printf("\n");
-    int row = 0;
-    for (i=0; i<=node_mask->size; ++i) {
-        if (numa_bitmask_isbitset(node_mask, i)) {
-            printf("%3d:", i);
-            for (j=0; j<num_nodes; ++j) {
-                int val = *(array_to_print + row*num_nodes + j);
-                if (val == -1) {
-                    printf("%6s ", "-");
-                } else {
-                    printf("%6d ", val);
+    for (init_id=0; init_id<=max_node_id; ++init_id) {
+        if (numa_bitmask_isbitset(numa_all_nodes_ptr, init_id)) {
+            printf("%3d:", init_id);
+            if (numa_node_to_cpus(init_id, node_cpumask)) {
+                printf("[ERROR] numa_node_to_cpus\n");
+                numa_free_cpumask(node_cpumask);
+                hwloc_topology_destroy(topology);
+                exit(-1);
+            }
+            if (numa_bitmask_weight(node_cpumask) == 0) {
+                for (target_id=0; target_id<=max_node_id; ++target_id) {
+                    if (numa_bitmask_isbitset(numa_all_nodes_ptr, target_id)) {
+                        printf("%6s ", "-");
+                    }
+                }
+            } else {
+                hwloc_uint64_t attr_val;
+                struct hwloc_location initiator;
+                hwloc_obj_t init_node = hwloc_get_numanode_obj_by_os_index(topology, init_id);
+                initiator.type = HWLOC_LOCATION_TYPE_CPUSET;
+                initiator.location.cpuset = init_node->cpuset;
+                for (target_id=0; target_id<=max_node_id; ++target_id) {
+                    if (numa_bitmask_isbitset(numa_all_nodes_ptr, target_id)) {
+                        hwloc_obj_t target_node = hwloc_get_numanode_obj_by_os_index(topology,
+                                                                                     target_id);
+                        int err = hwloc_memattr_get_value(topology, mem_attr, target_node, &initiator,
+                                                          0, &attr_val);
+                        if (err) {
+                            printf("%6s ", "X");
+                        } else {
+                            printf("%6lu ", attr_val);
+                        }
+                    }
                 }
             }
-            row++;
+            printf("\n");
         }
-        printf("\n");
     }
 }
 
 static int print_all(void)
 {
-    int num_nodes = numa_num_configured_nodes();
-    int num_node_max_id = numa_max_node();
-    int err;
-    int i = 0;
-    int j = 0;
-
-    hwloc_topology_t topology;
-    hwloc_obj_t init_node = NULL;
-    err = numa_available();
+    int err = numa_available();
     if (err == -1) {
-        printf("NUMA not available\n");
+        printf("[ERROR] NUMA not available\n");
         return -1;
     }
     err = hwloc_topology_init(&topology);
     if (err) {
-        printf("hwloc initialization failed\n");
+        printf("[ERROR] hwloc initialization failed\n");
         return -1;
     }
     err = hwloc_topology_load(topology);
     if (err) {
-        printf("hwloc topology load failed\n");
+        printf("[ERROR] hwloc topology load failed\n");
         hwloc_topology_destroy(topology);
         return -1;
     }
-    node_mask = numa_bitmask_alloc(num_node_max_id+1);
-    if (!node_mask) {
-        printf("numa_bitmask_alloc failed\n");
+    node_cpumask = numa_allocate_cpumask();
+    if (!node_cpumask) {
+        printf("[ERROR] numa_allocate_cpumask\n");
         hwloc_topology_destroy(topology);
         return -1;
     }
 
-    int *b_array = (int *)malloc(num_nodes * num_nodes * sizeof(int));
-    int *l_array = (int *)malloc(num_nodes * num_nodes * sizeof(int));
-    if (b_array == NULL) {
-        printf("malloc b_array failed\n");
-        goto free_numa_bitmask_alloc;
-    }
-    if (l_array == NULL) {
-        printf("malloc l_array failed\n");
-        goto free_bandwidth_array;
-    }
-    while ((init_node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE,
-                                                   init_node)) != NULL) {
-        numa_bitmask_setbit(node_mask, init_node->os_index);
-        hwloc_obj_t target_node = NULL;
-        j = 0;
-        while ((target_node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE,
-                                                         target_node)) != NULL) {
-            hwloc_uint64_t mem_attr;
-            struct hwloc_location initiator;
-            initiator.type = HWLOC_LOCATION_TYPE_CPUSET;
-            initiator.location.cpuset = init_node->cpuset;
+    print_attr(HWLOC_MEMATTR_ID_BANDWIDTH);
+    print_attr(HWLOC_MEMATTR_ID_LATENCY);
 
-            err = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_BANDWIDTH, target_node,
-                                          &initiator, 0, &mem_attr);
-            *(b_array + i*num_nodes + j) = (err) ? -1 : mem_attr;
-
-            err = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_LATENCY, target_node,
-                                          &initiator, 0, &mem_attr);
-            *(l_array + i*num_nodes + j) = (err) ? -1 : mem_attr;
-
-            j++;
-        }
-        i++;
-    }
-    print_array(b_array, "Node bandwidth [MiB/s]:");
-    print_array(l_array, "Node latency [ns]:");
-
-    free(l_array);
-
-free_bandwidth_array:
-    free(b_array);
-
-free_numa_bitmask_alloc:
-    numa_bitmask_free(node_mask);
+    numa_free_cpumask(node_cpumask);
 
     hwloc_topology_destroy(topology);
     return 0;
@@ -125,7 +110,7 @@ free_numa_bitmask_alloc:
 #else
 static int print_all(void)
 {
-    printf("Libhwloc is not supported\n");
+    printf("[ERROR] Libhwloc is not supported\n");
     return -1;
 }
 #endif


### PR DESCRIPTION
- using hwloc_get_next_obj_by_type don't guarantee the order of
 NUMA id(s)
- simpilfy the example - avoid char buffer allocations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/465)
<!-- Reviewable:end -->
