### PR TITLE
Add tbb::concurrent_hash_map example with memkind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /examples/hello_memkind_debug
 /examples/memkind_allocated
 /examples/memkind_cpp_allocator
+/examples/memkind_cpp_concurrent_hash_map
 /examples/memkind_get_stat
 /examples/pmem_alignment
 /examples/pmem_and_dax_kmem_kind

--- a/MANIFEST
+++ b/MANIFEST
@@ -26,6 +26,7 @@ examples/hello_memkind_example.c
 examples/memkind_allocated.hpp
 examples/memkind_allocated_example.cpp
 examples/memkind_cpp_allocator.cpp
+examples/memkind_cpp_concurrent_hash_map.cpp
 examples/memkind_decorator_debug.c
 examples/memkind_get_stat.c
 examples/pmem_alignment.c

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Copyright (C) 2014 - 2020 Intel Corporation.
+# Copyright (C) 2014 - 2021 Intel Corporation.
 
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
@@ -245,6 +245,25 @@ if test "x$enable_heap_manager" = "x1" ; then
   AC_DEFINE([MEMKIND_ENABLE_HEAP_MANAGER], [], [Enable heap manager])
 fi
 AC_SUBST([enable_heap_manager])
+
+#============================tbb examples===========================================
+AC_ARG_ENABLE([tbb-examples],
+  [AS_HELP_STRING([--enable-tbb-examples], [Build examples which require tbb])],
+[if test "x$enable_tbb_examples" = "xno" ; then
+  enable_tbb_examples="0"
+else
+  enable_tbb_examples="1"
+fi
+],
+[enable_tbb_examples="0"]
+)
+
+if test "x$enable_tbb_examples" = "x1" ; then
+  AC_CHECK_LIB(tbb, main, [], [AC_MSG_ERROR([libtbb is required if enable-tbb-examples is set])])
+fi
+
+AC_SUBST([enable_tbb_examples])
+AM_CONDITIONAL([ENABLE_TXX_EXAMPLES], [test "x$enable_tbb_examples" = x1])
 
 #============================cxx11=============================================
 

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -24,6 +24,10 @@ if HAVE_CXX11
 noinst_PROGRAMS += examples/memkind_allocated
 noinst_PROGRAMS += examples/memkind_cpp_allocator
 noinst_PROGRAMS += examples/pmem_cpp_allocator
+
+if ENABLE_TXX_EXAMPLES
+noinst_PROGRAMS += examples/memkind_cpp_concurrent_hash_map
+endif
 endif
 
 examples_autohbw_candidates_LDADD = libmemkind.la
@@ -49,6 +53,10 @@ if HAVE_CXX11
 examples_memkind_allocated_LDADD = libmemkind.la
 examples_memkind_cpp_allocator_LDADD  = libmemkind.la
 examples_pmem_cpp_allocator_LDADD = libmemkind.la
+
+if ENABLE_TXX_EXAMPLES
+examples_memkind_cpp_concurrent_hash_map_LDADD = libmemkind.la
+endif
 endif
 
 examples_autohbw_candidates_SOURCES = examples/autohbw_candidates.c
@@ -72,6 +80,16 @@ if HAVE_CXX11
 examples_memkind_allocated_SOURCES = examples/memkind_allocated_example.cpp examples/memkind_allocated.hpp
 examples_memkind_cpp_allocator_SOURCES = examples/memkind_cpp_allocator.cpp
 examples_pmem_cpp_allocator_SOURCES = examples/pmem_cpp_allocator.cpp
+
+if ENABLE_TXX_EXAMPLES
+examples_memkind_cpp_concurrent_hash_map_SOURCES = examples/memkind_cpp_concurrent_hash_map.cpp
+endif
+endif
+
+if HAVE_CXX11
+if ENABLE_TXX_EXAMPLES
+examples_memkind_cpp_concurrent_hash_map_LDFLAGS = -ltbb
+endif
 endif
 
 clean-local:

--- a/examples/README
+++ b/examples/README
@@ -67,6 +67,14 @@ and free memory without a need to remember which kind it belongs to.
 This example shows usage of C++ allocator mechanism designed for file-backed memory
 kind with different data structures like: vector, list and map.
 
+## memkind_cpp_concurrent_hash_map.cpp
+
+This example shows how to use tbb::concurrent_hash_map with memkind pmem allocator. The example
+also customizes concurrent_hash_map with a DRAM-resident lock type (which improves performance).
+
+To enable this example, you must set --enable-tbb-example=1 during configure step and have tbb
+installed (in version at least XXX).
+
 ## Other memkind examples
 
 ### memkind_get_stat.c

--- a/examples/memkind_cpp_concurrent_hash_map.cpp
+++ b/examples/memkind_cpp_concurrent_hash_map.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright (C) 2021 Intel Corporation. */
+
+
+#include <pmem_allocator.h>
+#include <memkind.h>
+
+#include <tbb/concurrent_hash_map.h>
+#include <tbb/spin_rw_mutex.h>
+
+#include <chrono>
+#include <memory>
+#include <iostream>
+#include <sys/stat.h>
+
+struct dram_mutex {
+    using scoped_lock = tbb::spin_rw_mutex::scoped_lock;
+
+    dram_mutex()
+    {
+        mtx = std::unique_ptr<tbb::spin_rw_mutex>(new tbb::spin_rw_mutex);
+    }
+
+    operator tbb::spin_rw_mutex &()
+    {
+        return *mtx;
+    }
+
+    // Mutex traits
+    static const bool is_rw_mutex = true;
+    static const bool is_recursive_mutex = true;
+    static const bool is_fair_mutex = true;
+
+    std::unique_ptr<tbb::spin_rw_mutex> mtx;
+};
+
+using allocator_type = libmemkind::pmem::allocator<std::pair<const int, int>>;
+using map_type =
+    tbb::concurrent_hash_map<int, int, tbb::tbb_hash_compare<int>, allocator_type, dram_mutex>;
+
+static constexpr int NUM_ELEMENTS = 100000;
+static constexpr size_t max_pmem_size = 1024*1024*1024;
+
+void example(std::string pmem_directory)
+{
+    const size_t max_pmem_size = 1024*1024*1024;
+
+    allocator_type alloc(pmem_directory, max_pmem_size);
+    map_type map(alloc);
+
+    std::chrono::steady_clock::time_point start, end;
+    start = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < NUM_ELEMENTS; i++) {
+        map.insert(typename map_type::value_type(i, i));
+    }
+
+    end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>
+                    (end - start).count();
+
+    std::cout << "Inserts took: " << duration << " ms" << std::endl;
+}
+
+int main(int argc, char *argv[])
+{
+    const char *pmem_directory = "/tmp/";
+
+    if (argc > 2) {
+        std::cerr << "Usage: memkind_cpp_concurrent_hash_map [directory path]\n"
+                  << "\t[directory path] - directory where temporary file is created (default = \"/tmp/\")"
+                  << std::endl;
+        return 0;
+    } else if (argc == 2) {
+        struct stat st;
+        if (stat(argv[1], &st) != 0 || !S_ISDIR(st.st_mode)) {
+            fprintf(stderr,"%s : Invalid path to pmem kind directory\n", argv[1]);
+            return 1;
+        }
+        int status = memkind_check_dax_path(argv[1]);
+        if (!status) {
+            std::cout << "PMEM kind %s is on DAX-enabled File system.\n" << std::endl;
+        } else {
+            std::cout << "PMEM kind %s is not on DAX-enabled File system.\n" << std::endl;
+        }
+        pmem_directory = argv[1];
+    }
+
+    example(pmem_directory);
+
+    return 0;
+}

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Copyright (C) 2014 - 2020 Intel Corporation.
+# Copyright (C) 2014 - 2021 Intel Corporation.
 
 AM_CPPFLAGS += -Itest/gtest_fused -DMEMKIND_DEPRECATED\(x\)=x
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [x] All newly added files have proprietary license (if necessary)
- [x] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
I don't know how to best handle tbb detection so I'm open for suggestions. Right now, I just added a flag which can be used to enable/disable the example. If tbb is installed in some non-standard location then the user would also have to provide correct paths to CXXFLAGS (-I and -L). Do you have any better ideas?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/468)
<!-- Reviewable:end -->
