### PR TITLE
Look at bandwidth between initiator and target when MEMKIND_HBW is used

### DIFF
--- a/include/memkind/internal/memkind_bitmask.h
+++ b/include/memkind/internal/memkind_bitmask.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #include <numa.h>
 
-typedef int (*get_node_bitmask)(struct bitmask **);
+typedef int (*get_node_bitmask)(int init_node, struct bitmask **);
 
 int set_closest_numanode(get_node_bitmask get_bitmask, void **closest_numanode,
                          int num_cpu, memkind_node_variant_t node_variant);

--- a/include/memkind/internal/memkind_mem_attributes.h
+++ b/include/memkind/internal/memkind_mem_attributes.h
@@ -17,7 +17,8 @@ typedef enum memory_attribute_t {
 
 int get_per_cpu_local_nodes_mask(struct bitmask ***nodes_mask,
                                  memkind_node_variant_t node_variant, memory_attribute_t attr);
-int get_mem_attributes_hbw_nodes_mask(struct bitmask **hbw_node_mask);
+int get_mem_attributes_hbw_nodes_mask(int init_node,
+                                      struct bitmask **hbw_node_mask);
 
 #ifdef __cplusplus
 }

--- a/src/memkind_dax_kmem.c
+++ b/src/memkind_dax_kmem.c
@@ -91,7 +91,7 @@ static int get_dax_kmem_nodemask(struct bitmask **bm)
 }
 #endif
 
-static int memkind_dax_kmem_get_nodemask(struct bitmask **bm)
+static int memkind_dax_kmem_get_nodemask(int init_node, struct bitmask **bm)
 {
     char *nodes_env = memkind_get_env("MEMKIND_DAX_KMEM_NODES");
     if (nodes_env) {

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -353,7 +353,7 @@ static int get_legacy_hbw_nodes_mask(struct bitmask **hbw_node_mask)
     return MEMKIND_ERROR_UNAVAILABLE;
 }
 
-static int memkind_hbw_get_nodemask(struct bitmask **bm)
+static int memkind_hbw_get_nodemask(int init_node, struct bitmask **bm)
 {
     char *nodes_env = memkind_get_env("MEMKIND_HBW_NODES");
     if (nodes_env) {
@@ -363,7 +363,7 @@ static int memkind_hbw_get_nodemask(struct bitmask **bm)
         if(is_hbm_legacy_supported(cpu)) {
             return get_legacy_hbw_nodes_mask(bm);
         } else {
-            return get_mem_attributes_hbw_nodes_mask(bm);
+            return get_mem_attributes_hbw_nodes_mask(init_node, bm);
         }
     }
 }


### PR DESCRIPTION
- from this change, an initiator node can't allocate from target node using MEMKIND_HBW if memory bandwidth between these nodes is below HBW threshold
- this fixes issue #481

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/485)
<!-- Reviewable:end -->
