### PR TITLE
Memkind_hmat_tests changes

### DIFF
--- a/test/memkind_hmat_tests.cpp
+++ b/test/memkind_hmat_tests.cpp
@@ -82,7 +82,7 @@ TEST_P(MemkindHMATFunctionalTestsParam, test_tc_memkind_HMAT_without_hwloc)
         if (tp.is_KN_family_supported() && (memory_kind == MEMKIND_HBW ||
                                             memory_kind == MEMKIND_HBW_ALL)) {
             EXPECT_TRUE(ptr != nullptr);
-            memkind_free(MEMKIND_HBW, ptr);
+            memkind_free(memory_kind, ptr);
         } else
             EXPECT_TRUE(ptr == nullptr);
     } else {

--- a/test/memory_topology.h
+++ b/test/memory_topology.h
@@ -33,7 +33,7 @@ private:
 
     virtual MapNodeSet HBW_all_nodes() const
     {
-        return {};
+        return HBW_nodes();
     }
 
     virtual MapNodeSet Capacity_local_nodes() const
@@ -185,12 +185,6 @@ private:
         return nodeset_map;
     }
 
-    MapNodeSet HBW_all_nodes() const final
-    {
-        MapNodeSet nodeset_map;
-        nodeset_map.emplace(NodeSet(0, {1}));
-        return nodeset_map;
-    }
 
     MapNodeSet Bandwidth_local_nodes() const final
     {
@@ -450,13 +444,6 @@ private:
         return nodeset_map;
     }
 
-    MapNodeSet HBW_all_nodes() const final
-    {
-        MapNodeSet nodeset_map;
-        nodeset_map.emplace(NodeSet(0, {2}));
-        nodeset_map.emplace(NodeSet(1, {3}));
-        return nodeset_map;
-    }
 
     MapNodeSet Capacity_local_nodes() const final
     {
@@ -561,16 +548,6 @@ class CLX_4_var1_HBW : public AbstractTopology
 {
 private:
     MapNodeSet HBW_nodes() const final
-    {
-        MapNodeSet nodeset_map;
-        nodeset_map.emplace(NodeSet(0, {4}));
-        nodeset_map.emplace(NodeSet(1, {5}));
-        nodeset_map.emplace(NodeSet(2, {6}));
-        nodeset_map.emplace(NodeSet(3, {7}));
-        return nodeset_map;
-    }
-
-    MapNodeSet HBW_all_nodes() const final
     {
         MapNodeSet nodeset_map;
         nodeset_map.emplace(NodeSet(0, {4}));


### PR DESCRIPTION
- First commit fix wrong kind reference in test_tc_memkind_HMAT_without_hwloc - fixes 57c3e89
- Second provide by default call to HBW_nodes in HBW_all_nodes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/499)
<!-- Reviewable:end -->
