### PR TITLE
Add check for affinity mask.

### DIFF
--- a/src/memkind_mem_attributes.c
+++ b/src/memkind_mem_attributes.c
@@ -12,6 +12,7 @@
 #include <memkind/internal/vec.h>
 
 #include <hwloc.h>
+#include <hwloc/linux.h>
 #include <hwloc/linux-libnuma.h>
 #define MEMKIND_HBW_THRESHOLD_DEFAULT (200 * 1024) // Default threshold is 200 GB/s
 
@@ -225,6 +226,7 @@ int set_closest_numanode_mem_attr(void **numanode,
     hwloc_topology_t topology;
     hwloc_obj_t init_node = NULL;
     hwloc_cpuset_t node_cpus = NULL;
+    hwloc_cpuset_t affinity_cpus = NULL;
 
     if (hbw_threshold_env) {
         log_info("Environment variable MEMKIND_HBW_THRESHOLD detected: %s.",
@@ -251,11 +253,25 @@ int set_closest_numanode_mem_attr(void **numanode,
         goto hwloc_destroy;
     }
 
+    affinity_cpus = hwloc_bitmap_alloc();
+    if (MEMKIND_UNLIKELY(affinity_cpus == NULL)) {
+        log_err("hwloc_bitmap_alloc failed");
+        status = MEMKIND_ERROR_UNAVAILABLE;
+        goto hwloc_destroy;
+    }
+
+    err = hwloc_linux_get_tid_cpubind(topology, 0, affinity_cpus);
+    if (MEMKIND_UNLIKELY(err)) {
+        log_err("hwloc_linux_get_tid_cpubind failed");
+        status = MEMKIND_ERROR_RUNTIME;
+        goto node_affinity_cpu_free;
+    }
+
     node_cpus = hwloc_bitmap_alloc();
     if (MEMKIND_UNLIKELY(node_cpus == NULL)) {
         log_err("hwloc_bitmap_alloc failed");
         status = MEMKIND_ERROR_UNAVAILABLE;
-        goto hwloc_destroy;
+        goto node_affinity_cpu_free;
     }
 
     VEC(vec_temp, int) current_dest_nodes = VEC_INITIALIZER;
@@ -275,7 +291,7 @@ int set_closest_numanode_mem_attr(void **numanode,
         hwloc_obj_t target = NULL;
         int min_distance = INT_MAX;
 
-        //skip node which could not be a initiator
+        // skip node which could not be a initiator
         if (hwloc_bitmap_isincluded(init_node->cpuset, node_cpus)) {
             log_info("Node %d skipped - no CPU detected in initiator Node.",
                      init_node->os_index);
@@ -283,6 +299,13 @@ int set_closest_numanode_mem_attr(void **numanode,
         }
 
         hwloc_bitmap_or(node_cpus, node_cpus, init_node->cpuset);
+
+        // skip  node if all CPU's from node are excluded from process
+        if (!hwloc_bitmap_isincluded(init_node->cpuset, affinity_cpus)) {
+            log_info("Node %d skipped - CPU's from Node excluded from affinity mask.",
+                     init_node->os_index);
+            continue;
+        }
 
         initiator.type = HWLOC_LOCATION_TYPE_CPUSET;
         initiator.location.cpuset = init_node->cpuset;
@@ -356,6 +379,9 @@ free_current_dest_nodes:
 
 node_cpu_free:
     hwloc_bitmap_free(node_cpus);
+
+node_affinity_cpu_free:
+    hwloc_bitmap_free(affinity_cpus);
 
 hwloc_destroy:
     hwloc_topology_destroy(topology);


### PR DESCRIPTION
```
 +-------+    +-------+
 | Node0 |    | Node1 |
 | CPU   |----| CPU   |
 | DRAM  |    | DRAM  |
 +-------+    +-------+
     |            |
     |            |
 +-------+    +--------+
 | Node2 |    | Node3  |
 |  HBW  |    | no-HBW |
 +-------+    +--------+
```

 In architecture like above
 Assuming that only High Bandwidth connection is provided by
 Node 0 -> Node 2 (which fulfill MEMKIND_HBW_THRESHOLD       condition), allocation using MEMKIND_HBW will fail since
 Node 1 got no access to High Bandwidth memory.

 This patch provides a possibility to use MEMKIND_HBW in case
 of CPU pinning application only to initiator Node(s), which have access to high bandwidth memory.
 In the example above, this could be achieved by e.g. using:
 numactl --cpunodebind=0 ./out

TODO:

- [ ] Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/505)
<!-- Reviewable:end -->
