### PR TITLE
Add malloc_stats_print() to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@
 /test/pmem_multithreads_onekind
 /test/pmem_test
 /test/pmem_usable_size
+/test/stats_print_test_helper
 /test/trace_mechanism_test_helper
 /test/defrag_reallocate
 /vs

--- a/MANIFEST
+++ b/MANIFEST
@@ -546,6 +546,7 @@ test/random_sizes_allocator.h
 test/run_alloc_benchmark.sh
 test/static_kinds_list.h
 test/static_kinds_tests.cpp
+test/stats_print_test_helper.c
 test/tbbmalloc.h
 test/test.sh
 test/test_dax_kmem.sh

--- a/copying_headers/MANIFEST.freeBSD
+++ b/copying_headers/MANIFEST.freeBSD
@@ -188,6 +188,7 @@ test/random_sizes_allocator.h
 test/run_alloc_benchmark.sh
 test/static_kinds_list.h
 test/static_kinds_tests.cpp
+test/stats_print_test_helper.c
 test/tbbmalloc.h
 test/test.sh
 test/test_dax_kmem.sh

--- a/examples/memkind_get_stat.c
+++ b/examples/memkind_get_stat.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-2-Clause
-/* Copyright (C) 2019 - 2020 Intel Corporation. */
+/* Copyright (C) 2019 - 2021 Intel Corporation. */
 
 #include <memkind.h>
 #include <stdio.h>
@@ -19,6 +19,12 @@ int main()
 
     fprintf(stdout,
             "This example shows how to use memkind API to retrieve information about allocation stats.\n");
+
+    fprintf(stdout,
+            "Summary statistics from memkind_stats_print() function:\n");
+    memkind_stats_print(NULL, NULL, MEMKIND_STAT_PRINT_ALL);
+    fprintf(stdout,
+            "End of summary statistics from memkind_stats_print() function.\n");
 
     snprintf(ptr_regular, size,
              "Hello world from regular kind memory - ptr_regular.\n");

--- a/include/memkind.h
+++ b/include/memkind.h
@@ -143,6 +143,60 @@ typedef enum memkind_stat_type {
     MEMKIND_STAT_TYPE_MAX_VALUE
 } memkind_stat_type;
 
+/// \brief Memory statistics print options
+typedef enum memkind_stat_print_opt {
+
+    /**
+     * Print all stats
+     */
+    MEMKIND_STAT_PRINT_ALL                        = 0,
+
+    /**
+     * Print stats in JSON format
+     */
+    MEMKIND_STAT_PRINT_JSON_FORMAT                 = 1U << 0,
+
+    /**
+     * Omit general information that never changes during execution
+     */
+    MEMKIND_STAT_PRINT_OMIT_GENERAL                = 1U << 1,
+
+    /**
+     * Omit merged arena statistics
+     */
+    MEMKIND_STAT_PRINT_OMIT_MERGED_ARENA           = 1U << 2,
+
+    /**
+     * Omit destroyed merged arena statistics
+     */
+    MEMKIND_STAT_PRINT_OMIT_DESTROYED_MERGED_ARENA = 1U << 3,
+
+    /**
+     * Omit per arena statistics
+     */
+    MEMKIND_STAT_PRINT_OMIT_PER_ARENA              = 1U << 4,
+
+    /**
+     * Omit per size class statistics for bins
+     */
+    MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_BINS    = 1U << 5,
+
+    /**
+     * Omit per size class statistics for large objects
+     */
+    MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_LARGE   = 1U << 6,
+
+    /**
+     * Omit all mutex statistics
+     */
+    MEMKIND_STAT_PRINT_OMIT_MUTEX                  = 1U << 7,
+
+    /**
+     * Omit extent statistics
+     */
+    MEMKIND_STAT_PRINT_OMIT_EXTENT                 = 1U << 8,
+} memkind_stat_print_opt;
+
 /// \brief Forward declaration of memkind configuration
 struct memkind_config;
 
@@ -362,6 +416,17 @@ int memkind_update_cached_stats(void);
 /// \return Memkind operation status, MEMKIND_SUCCESS on success, other values on failure
 ///
 int memkind_get_stat(memkind_t kind, memkind_stat_type stat, size_t *value);
+
+///
+/// \brief Print human-readable malloc statistics
+/// \note STANDARD API
+/// \param write_cb pointer to a callback function which prints the statistics, pass NULL to use the default one
+/// \param cbopaque data passed to write_cb function
+/// \param opts additional options altering the contents of statistics output
+/// \return Memkind operation status, MEMKIND_SUCCESS on success, MEMKIND_ERROR_INVALID on failure
+///
+int memkind_stats_print(void (*write_cb) (void *, const char *),
+                        void *cbopaque, memkind_stat_print_opt opts);
 
 /* HEAP MANAGEMENT INTERFACE */
 

--- a/include/memkind/internal/heap_manager.h
+++ b/include/memkind/internal/heap_manager.h
@@ -14,3 +14,5 @@ int heap_manager_update_cached_stats(void);
 int heap_manager_get_stat(memkind_stat_type stat, size_t *value);
 void *heap_manager_defrag_reallocate(void *ptr);
 int heap_manager_set_bg_threads(bool state);
+int heap_manager_stats_print(void (*write_cb) (void *, const char *),
+                             void *cbopaque, memkind_stat_print_opt opts);

--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -53,6 +53,8 @@ int memkind_arena_get_global_stat(memkind_stat_type stat_type, size_t *stat);
 void *memkind_arena_defrag_reallocate(struct memkind *kind, void *ptr);
 void *memkind_arena_defrag_reallocate_with_kind_detect(void *ptr);
 bool memkind_get_hog_memory(void);
+int memkind_arena_stats_print(void (*write_cb) (void *, const char *),
+                              void *cbopaque, memkind_stat_print_opt opts);
 #ifdef __cplusplus
 }
 #endif

--- a/include/memkind/internal/memkind_private.h
+++ b/include/memkind/internal/memkind_private.h
@@ -44,6 +44,7 @@ extern "C" {
 #define jemk_malloc_usable_size     JE_SYMBOL(malloc_usable_size)
 #define jemk_arenalookupx           JE_SYMBOL(arenalookupx)
 #define jemk_check_reallocatex      JE_SYMBOL(check_reallocatex)
+#define jemk_malloc_stats_print     JE_SYMBOL(malloc_stats_print)
 
 enum memkind_const_private {
     MEMKIND_NAME_LENGTH_PRIV = 64

--- a/include/memkind/internal/tbb_wrapper.h
+++ b/include/memkind/internal/tbb_wrapper.h
@@ -39,6 +39,10 @@ void *tbb_pool_defrag_reallocate_with_kind_detect(void *ptr);
 /* set background threads for TBB (unsupported) */
 int tbb_set_bg_threads(bool state);
 
+/* print malloc statistics for TBB (unsupported) */
+int tbb_stats_print(void (*write_cb) (void *, const char *), void *cbopaque,
+                    memkind_stat_print_opt opts);
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -77,6 +77,8 @@ This header expose STANDARD and EXPERIMENTAL API. API Standards are described be
 .BI "int memkind_update_cached_stats(void);"
 .br
 .BI "int memkind_get_stat(memkind_t " "kind" ", memkind_stat " "stat" ", size_t " "*value" );
+.br
+.BI "int memkind_stats_print(void " "(*write_cb) (void *, const char *)" ", void " "*cbopaque" ", memkind_stat_print_opt "opts" );
 .sp
 .B "DECORATORS:"
 .br
@@ -592,6 +594,33 @@ You need to call
 before calling
 .BR memkind_get_stat ()
 because statistics are cached by memkind library.
+.PP
+.BR memkind_stats_print ()
+prints summary statistics. This function wraps jemalloc's function
+.BR je_malloc_stats_print ().
+Uses
+.I write_cb
+function to print the output. While providing custom writer function, use
+.BR syscall(2)
+rather than
+.BR write(2).
+Pass
+.IR NULL
+in order to use the default
+.I write_cb
+function which prints the output to the stderr. Use
+.I cbopaque
+parameter in order to pass some data to your
+.I write_cb
+function. Pass additional options using
+.IR "opts".
+For more details on
+.I opts
+see the
+.B "MEMORY STATISTICS PRINT OPTIONS"
+section below.
+Returns MEMKIND_ERROR_INVALID when failed to parse options string, MEMKIND_SUCCESS on success.
+.PP
 .sp
 .B "DECORATORS:"
 .br
@@ -962,6 +991,38 @@ Total number of bytes in active pages.
 .TP
 .B MEMKIND_STAT_TYPE_ALLOCATED
 Total number of allocated bytes.
+.SH "MEMORY STATISTICS PRINT OPTIONS"
+The available options for printing statistics:
+.TP
+.B MEMKIND_STAT_PRINT_ALL
+Print all statistics.
+.TP
+.B MEMKIND_STAT_PRINT_JSON_FORMAT
+Print statistics in JSON format.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_GENERAL
+Omit general information that never changes during execution.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_MERGED_ARENA
+Omit merged arena statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_DESTROYED_MERGED_ARENA
+Omit destroyed merged arena statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_PER_ARENA
+Omit per arena statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_BINS
+Omit per size class statistics for bins.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_LARGE
+Omit per size class statistics for large objects.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_MUTEX
+Omit all mutex statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_EXTENT
+Omit extent statistics.
 .SH "ERRORS"
 .TP
 .BR memkind_posix_memalign ()
@@ -1202,4 +1263,6 @@ Copyright (C) 2014 - 2021 Intel Corporation. All rights reserved.
 .BR memkind_arena (3),
 .BR memkind_hbw (3),
 .BR memkind_hugetlb (3),
-.BR memkind_pmem (3)
+.BR memkind_pmem (3),
+.BR syscall(2),
+.BR write(2)

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -30,6 +30,8 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .BI "int memkind_arena_set_max_bg_threads(size_t " "threads_limit" );
 .BI "int memkind_arena_set_bg_threads(bool " "state" );
 .br
+.BI "int memkind_arena_stats_print(void " "(*write_cb) (void *, const char *)" ", void " "*cbopaque" ", memkind_stat_print_opt " "opts" );
+.br
 .SH DESCRIPTION
 This header file is a collection of functions can be used to populate
 the memkind operations structure for memory kinds that use jemalloc.
@@ -193,6 +195,62 @@ specify limit of background threads which can be enabled ( 0 means no limit).
 .BR memkind_arena_set_bg_threads ()
 enables/disables internal background worker threads in jemalloc.
 .PP
+.BR memkind_arena_stats_print ()
+prints summary statistics. This function wraps jemalloc's function
+.BR je_malloc_stats_print ().
+Uses
+.I write_cb
+function to print the output. While providing custom writer function, use
+.BR syscall(2)
+rather than
+.BR write(2)
+Pass
+.IR NULL
+in order to use the default write_cb function which prints the output to the stderr. Use
+.I cbopaque
+parameter in order to pass some data to your
+.I write_cb
+function. Pass additional options using
+.IR "opts".
+For more details on
+.I opts
+see the
+.B "MEMORY STATISTICS PRINT OPTIONS"
+section below.
+Returns MEMKIND_ERROR_INVALID when failed to parse options string, MEMKIND_SUCCESS on success.
+.SH "MEMORY STATISTICS PRINT OPTIONS"
+The available options for printing statistics:
+.TP
+.B MEMKIND_STAT_PRINT_ALL
+Print all statistics.
+.TP
+.B MEMKIND_STAT_PRINT_JSON_FORMAT
+Print statistics in JSON format.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_GENERAL
+Omit general information that never changes during execution.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_MERGED_ARENA
+Omit merged arena statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_DESTROYED_MERGED_ARENA
+Omit destroyed merged arena statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_PER_ARENA
+Omit per arena statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_BINS
+Omit per size class statistics for bins.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_LARGE
+Omit per size class statistics for large objects.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_MUTEX
+Omit all mutex statistics.
+.TP
+.B MEMKIND_STAT_PRINT_OMIT_EXTENT
+Omit extent statistics.
+.PP
 .SH "COPYRIGHT"
 Copyright (C) 2014 - 2021 Intel Corporation. All rights reserved.
 .SH "SEE ALSO"
@@ -203,4 +261,6 @@ Copyright (C) 2014 - 2021 Intel Corporation. All rights reserved.
 .BR memkind_pmem (3),
 .BR jemalloc (3),
 .BR mbind (2),
-.BR mmap (2)
+.BR mmap (2),
+.BR syscall(2),
+.BR write(2)

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -10,24 +10,43 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .SH "SYNOPSIS"
 .sp
 .BI "int memkind_arena_create(struct memkind " "*kind" ", struct memkind_ops " "*ops" ", const char " "*name" );
+.br
 .BI "int memkind_arena_create_map(struct memkind " "*kind" ", extent_hooks_t " "*hooks" );
+.br
 .BI "int memkind_arena_destroy(struct memkind " "*kind" );
+.br
 .BI "void *memkind_arena_malloc(struct memkind " "*kind" ", size_t " "size" );
+.br
 .BI "void *memkind_arena_calloc(struct memkind " "*kind" ", size_t " "num" ", size_t " "size" );
+.br
 .BI "int memkind_arena_posix_memalign(struct memkind " "*kind" ", void " "**memptr" ", size_t " "alignment" ", size_t " "size" );
+.br
 .BI "void *memkind_arena_realloc(struct memkind " "*kind" ", void " "*ptr" ", size_t " "size" );
+.br
 .BI "void *memkind_arena_realloc_with_kind_detect(void " "*ptr" ", size_t " "size" );
+.br
 .BI "int memkind_thread_get_arena(struct memkind " "*kind" ", unsigned int " "*arena" ", size_t " "size" );
+.br
 .BI "int memkind_bijective_get_arena(struct memkind " "*kind" ", unsigned int " "*arena" ", size_t " "size" );
+.br
 .BI "struct memkind *get_kind_by_arena(unsigned " "arena_ind" );
+.br
 .BI "struct memkind *memkind_arena_detect_kind(void " "*ptr" );
+.br
 .BI "int memkind_arena_finalize(struct memkind " "*kind" );
+.br
 .BI "void memkind_arena_init(struct memkind " "*kind" );
+.br
 .BI "void memkind_arena_free(struct memkind " "*kind" ", void " "*ptr" );
+.br
 .BI "void memkind_arena_free_with_kind_detect(void " "*ptr" );
+.br
 .BI "size_t memkind_arena_malloc_usable_size(void " "*ptr" );
+.br
 .BI "int memkind_arena_update_memory_usage_policy(struct memkind " "*kind" ", memkind_mem_usage_policy " "policy" );
+.br
 .BI "int memkind_arena_set_max_bg_threads(size_t " "threads_limit" );
+.br
 .BI "int memkind_arena_set_bg_threads(bool " "state" );
 .br
 .BI "int memkind_arena_stats_print(void " "(*write_cb) (void *, const char *)" ", void " "*cbopaque" ", memkind_stat_print_opt " "opts" );

--- a/memkind.spec.mk
+++ b/memkind.spec.mk
@@ -215,6 +215,7 @@ ${memkind_test_dir}/pmem_test
 ${memkind_test_dir}/allocator_perf_tool_tests
 ${memkind_test_dir}/perf_tool
 ${memkind_test_dir}/autohbw_test_helper
+$(memkind_test_dir)/stats_print_test_helper
 ${memkind_test_dir}/trace_mechanism_test_helper
 $(memkind_test_dir)/memkind-afts.ts
 $(memkind_test_dir)/memkind-afts-ext.ts

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -23,6 +23,8 @@ struct heap_manager_ops {
     int (*heap_manager_get_stat)(memkind_stat_type stat, size_t *value);
     void *(*heap_manager_defrag_reallocate)(void *ptr);
     int (*heap_manager_set_bg_threads)(bool state);
+    int (*heap_manager_stats_print)(void (*write_cb) (void *, const char *),
+                                    void *cbopaque, memkind_stat_print_opt opts);
 };
 
 static struct heap_manager_ops arena_heap_manager_g = {
@@ -34,7 +36,8 @@ static struct heap_manager_ops arena_heap_manager_g = {
     .heap_manager_update_cached_stats = memkind_arena_update_cached_stats,
     .heap_manager_get_stat = memkind_arena_get_global_stat,
     .heap_manager_defrag_reallocate = memkind_arena_defrag_reallocate_with_kind_detect,
-    .heap_manager_set_bg_threads = memkind_arena_set_bg_threads
+    .heap_manager_set_bg_threads = memkind_arena_set_bg_threads,
+    .heap_manager_stats_print = memkind_arena_stats_print
 };
 
 static struct heap_manager_ops tbb_heap_manager_g = {
@@ -46,7 +49,8 @@ static struct heap_manager_ops tbb_heap_manager_g = {
     .heap_manager_update_cached_stats = tbb_update_cached_stats,
     .heap_manager_get_stat = tbb_get_global_stat,
     .heap_manager_defrag_reallocate = tbb_pool_defrag_reallocate_with_kind_detect,
-    .heap_manager_set_bg_threads = tbb_set_bg_threads
+    .heap_manager_set_bg_threads = tbb_set_bg_threads,
+    .heap_manager_stats_print = tbb_stats_print
 };
 
 static void set_heap_manager()
@@ -107,4 +111,10 @@ void *heap_manager_defrag_reallocate(void *ptr)
 int heap_manager_set_bg_threads(bool state)
 {
     return get_heap_manager()->heap_manager_set_bg_threads(state);
+}
+
+int heap_manager_stats_print(void (*write_cb) (void *, const char *),
+                             void *cbopaque, memkind_stat_print_opt opts)
+{
+    return get_heap_manager()->heap_manager_stats_print(write_cb, cbopaque, opts);
 }

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -40,25 +40,27 @@
 #include <unistd.h>
 
 #ifdef MEMKIND_ENABLE_HEAP_MANAGER
-#define m_detect_kind(ptr)             heap_manager_detect_kind(ptr)
-#define m_free(ptr)                    heap_manager_free(ptr)
-#define m_realloc(ptr, size)           heap_manager_realloc(ptr, size)
-#define m_usable_size(ptr)             heap_manager_malloc_usable_size(ptr)
-#define m_defrag_reallocate(ptr)       heap_manager_defrag_reallocate(ptr)
-#define m_get_global_stat(stat, value) heap_manager_get_stat(stat, value)
-#define m_update_cached_stats          heap_manager_update_cached_stats
-#define m_init                         heap_manager_init
-#define m_set_bg_threads(state)        heap_manager_set_bg_threads(state)
+#define m_detect_kind(ptr)                      heap_manager_detect_kind(ptr)
+#define m_free(ptr)                             heap_manager_free(ptr)
+#define m_realloc(ptr, size)                    heap_manager_realloc(ptr, size)
+#define m_usable_size(ptr)                      heap_manager_malloc_usable_size(ptr)
+#define m_defrag_reallocate(ptr)                heap_manager_defrag_reallocate(ptr)
+#define m_get_global_stat(stat, value)          heap_manager_get_stat(stat, value)
+#define m_update_cached_stats                   heap_manager_update_cached_stats
+#define m_init                                  heap_manager_init
+#define m_set_bg_threads(state)                 heap_manager_set_bg_threads(state)
+#define m_stats_print(write_cb, cbopaque, opts) heap_manager_stats_print(write_cb, cbopaque, opts)
 #else
-#define m_detect_kind(ptr)             memkind_arena_detect_kind(ptr)
-#define m_free(ptr)                    memkind_arena_free_with_kind_detect(ptr)
-#define m_realloc(ptr, size)           memkind_arena_realloc_with_kind_detect(ptr, size)
-#define m_usable_size(ptr)             memkind_default_malloc_usable_size(NULL, ptr)
-#define m_defrag_reallocate(ptr)       memkind_arena_defrag_reallocate_with_kind_detect(ptr)
-#define m_get_global_stat(stat, value) memkind_arena_get_global_stat(stat, value)
-#define m_update_cached_stats          memkind_arena_update_cached_stats
-#define m_init                         memkind_arena_init
-#define m_set_bg_threads(state)        memkind_arena_set_bg_threads(state)
+#define m_detect_kind(ptr)                      memkind_arena_detect_kind(ptr)
+#define m_free(ptr)                             memkind_arena_free_with_kind_detect(ptr)
+#define m_realloc(ptr, size)                    memkind_arena_realloc_with_kind_detect(ptr, size)
+#define m_usable_size(ptr)                      memkind_default_malloc_usable_size(NULL, ptr)
+#define m_defrag_reallocate(ptr)                memkind_arena_defrag_reallocate_with_kind_detect(ptr)
+#define m_get_global_stat(stat, value)          memkind_arena_get_global_stat(stat, value)
+#define m_update_cached_stats                   memkind_arena_update_cached_stats
+#define m_init                                  memkind_arena_init
+#define m_set_bg_threads(state)                 memkind_arena_set_bg_threads(state)
+#define m_stats_print(write_cb, cbopaque, opts) memkind_arena_stats_print(write_cb, cbopaque, opts)
 #endif
 
 /* Clear bits in x, but only this specified in mask. */
@@ -1007,4 +1009,10 @@ MEMKIND_EXPORT int memkind_check_dax_path(const char *pmem_dir)
 MEMKIND_EXPORT int memkind_set_bg_threads(bool state)
 {
     return m_set_bg_threads(state);
+}
+
+MEMKIND_EXPORT int memkind_stats_print(void (*write_cb) (void *, const char *),
+                                       void *cbopaque, memkind_stat_print_opt opts)
+{
+    return m_stats_print(write_cb, cbopaque, opts);
 }

--- a/src/tbb_wrapper.c
+++ b/src/tbb_wrapper.c
@@ -147,6 +147,13 @@ int tbb_update_cached_stats(void)
     return MEMKIND_ERROR_OPERATION_FAILED;
 }
 
+int tbb_stats_print(void (*write_cb) (void *, const char *), void *cbopaque,
+                    memkind_stat_print_opt opts)
+{
+    log_err("Malloc stats print is not supported in TBB");
+    return MEMKIND_ERROR_OPERATION_FAILED;
+}
+
 void *tbb_pool_defrag_reallocate_with_kind_detect(void *ptr)
 {
     log_err("Defrag reallocate method is not supported by TBB");

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -18,6 +18,7 @@ check_PROGRAMS += test/all_tests \
                   test/locality_test \
                   test/memkind_stat_test \
                   test/performance_test \
+                  test/stats_print_test_helper \
                   test/trace_mechanism_test_helper \
                   # end
 if HAVE_CXX11
@@ -62,6 +63,7 @@ test_environ_max_bg_threads_test_LDADD = libmemkind.la
 test_freeing_memory_segfault_test_LDADD = libmemkind.la
 test_gb_page_tests_bind_policy_LDADD = libmemkind.la
 test_memkind_stat_test_LDADD = libmemkind.la
+test_stats_print_test_helper_LDADD = libmemkind.la
 test_trace_mechanism_test_helper_LDADD = libmemkind.la
 
 if HAVE_CXX11
@@ -135,6 +137,7 @@ test_environ_max_bg_threads_test_SOURCES = test/environ_max_bg_threads_test.cpp
 test_freeing_memory_segfault_test_SOURCES = $(fused_gtest) test/freeing_memory_segfault_test.cpp
 test_gb_page_tests_bind_policy_SOURCES = $(fused_gtest) test/gb_page_tests_bind_policy.cpp test/trial_generator.cpp test/check.cpp
 test_memkind_stat_test_SOURCES = $(fused_gtest) test/memkind_stat_test.cpp
+test_stats_print_test_helper_SOURCES = test/stats_print_test_helper.c
 test_trace_mechanism_test_helper_SOURCES = test/trace_mechanism_test_helper.c
 
 #Tests based on Allocator Perf Tool

--- a/test/stats_print_test.py
+++ b/test/stats_print_test.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (C) 2021 Intel Corporation.
+
+import json
+import pytest
+from python_framework import CMD_helper
+import re
+
+
+class Test_malloc_stats_print(object):
+
+    cmd_helper = CMD_helper()
+    bin_path = cmd_helper.get_command_path("../stats_print_test_helper")
+    fail_msg = "Test failed with:\n {0}"
+    bin_param = ""
+    error_msg = "Error: {0} option not parsed correctly."
+
+    def run_test_binary(self):
+        command = " ".join([self.bin_path, self.bin_param])
+        output, retcode = self.cmd_helper.execute_cmd(command)
+        assert retcode == 0, \
+            self.fail_msg.format(
+                f"\nError: Execution of \'{command}\' returns {retcode}. Output: {output}")
+        return output, retcode
+
+    @pytest.mark.parametrize("bin_param", ["default", "stdout", "no_write_cb"])
+    def test_TC_MEMKIND_malloc_stats_print_check_output(self, bin_param):
+        """ This test checks if there is output from malloc_stats_print() memkind API function """
+        self.bin_param = bin_param
+        output, _ = self.run_test_binary()
+        assert output.endswith("--- End jemalloc statistics ---\n"), \
+            f"Error: Didn't get the expected output from the '{self.bin_path}' binary."
+
+    def test_TC_MEMKIND_malloc_stats_print_multi_opt_test(self):
+        """ This test checks output from malloc_stats_print() memkind API function when options
+        "MEMKIND_STAT_PRINT_JSON_FORMAT | MEMKIND_STAT_PRINT_OMIT_PER_ARENA | MEMKIND_STAT_PRINT_OMIT_EXTENT"
+        are passed to the function """
+        self.bin_param = "pass_opts"
+        output, _ = self.run_test_binary()
+        assert json.loads(output), \
+            self.error_msg.format("MEMKIND_STAT_PRINT_JSON_FORMAT")
+        assert "arenas[" not in output, \
+               self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_PER_ARENA")
+        assert "extents:" not in output, \
+               self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_EXTENT")
+
+    def test_TC_MEMKIND_malloc_stats_print_all_opts_test(self):
+        """ This test checks output from malloc_stats_print() memkind API function when all possible options
+        are passed to the function """
+        self.bin_param = "all_opts"
+        output, _ = self.run_test_binary()
+        assert json.loads(output), \
+            self.error_msg.format("MEMKIND_STAT_PRINT_JSON_FORMAT")
+        assert "version" not in output, \
+               self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_GENERAL")
+        assert "merged" not in output, \
+               self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_MERGED_ARENA")
+        assert "destroyed" not in output, \
+               self.error_msg.format(
+                   "MEMKIND_STAT_PRINT_OMIT_DESTROYED_MERGED_ARENA")
+        assert re.search(re.compile(r'(\d+)": {'), output) is None, \
+            self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_PER_ARENA")
+        assert "\"bins\"" not in output, \
+               self.error_msg.format(
+                   "MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_BINS")
+        assert "lextents" not in output, \
+               self.error_msg.format(
+                   "MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_LARGE")
+        assert "mutex" not in output, \
+               self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_MUTEX")
+        assert "\"extents\"" not in output, \
+               self.error_msg.format("MEMKIND_STAT_PRINT_OMIT_EXTENT")
+
+    def test_TC_MEMKIND_malloc_stats_print_negative_test(self):
+        """ This test checks if there is no output from malloc_stats_print() memkind API function when wrong arguments
+            are being passed to the function """
+        self.bin_param = "negative_test"
+        output, _ = self.run_test_binary()
+        assert len(output) == 0, \
+            f"Error: There should be no output from the '{self.bin_path}' binary."
+
+    def test_TC_MEMKIND_malloc_stats_print_opts_negative_test(self):
+        """ This test checks if there is a failure in parsing opts in malloc_stats_print() memkind API function
+            when wrong options string is passed to the function """
+        self.bin_param = "opts_negative_test"
+        _, retcode = self.run_test_binary()
+        assert retcode == 0, \
+            f"Error: '{self.bin_path}' binary should return 0 indicating that parsing opts string failed."

--- a/test/stats_print_test_helper.c
+++ b/test/stats_print_test_helper.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/* Copyright (C) 2021 Intel Corporation. */
+
+#include "memkind.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+void write_cb(void *cbopaque, const char *s)
+{
+    int fd = *((int *)cbopaque);
+    syscall(SYS_write, fd, s, strlen(s));
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        printf("Error: Wrong number of parameters. Exactly one expected.\n");
+        return -1;
+    }
+
+    int fd = -1;
+    if (strcmp(argv[1], "default") == 0) {
+        // default write_cb function should be called, write to stderr
+        return memkind_stats_print(NULL, NULL, MEMKIND_STAT_PRINT_ALL);
+    } else if (strcmp(argv[1], "stdout") == 0) {
+        fd = STDOUT_FILENO;
+        return memkind_stats_print(&write_cb, (void *)&fd, MEMKIND_STAT_PRINT_ALL);
+    } else if (strcmp(argv[1], "no_write_cb") == 0) {
+        // default write_cb function should be called, write to stderr
+        fd = STDOUT_FILENO;
+        return memkind_stats_print(NULL, (void *)&fd, MEMKIND_STAT_PRINT_ALL);
+    } else if (strcmp(argv[1], "pass_opts") == 0) {
+        // default write_cb function should be called, write to stderr
+        void *ptr = memkind_malloc(MEMKIND_REGULAR, 1024);
+
+        int ret = memkind_stats_print(NULL, NULL,
+                                      MEMKIND_STAT_PRINT_JSON_FORMAT
+                                      | MEMKIND_STAT_PRINT_OMIT_PER_ARENA
+                                      | MEMKIND_STAT_PRINT_OMIT_EXTENT);
+
+        memkind_free(MEMKIND_REGULAR, ptr);
+        return ret;
+    } else if (strcmp(argv[1], "all_opts") == 0) {
+        const char *dir = "/tmp";
+        size_t max_size = MEMKIND_PMEM_MIN_SIZE;
+        struct memkind *kind = NULL;
+        memkind_create_pmem(dir, max_size, &kind);
+        void *ptr = memkind_malloc(kind, 1024);
+        memkind_free(kind, ptr);
+        memkind_destroy_kind(kind);
+        memkind_create_pmem(dir, max_size, &kind);
+        ptr = memkind_malloc(kind, 1024);
+
+        int ret = memkind_stats_print(NULL, NULL,
+                                      MEMKIND_STAT_PRINT_JSON_FORMAT
+                                      | MEMKIND_STAT_PRINT_OMIT_GENERAL
+                                      | MEMKIND_STAT_PRINT_OMIT_MERGED_ARENA
+                                      | MEMKIND_STAT_PRINT_OMIT_DESTROYED_MERGED_ARENA
+                                      | MEMKIND_STAT_PRINT_OMIT_PER_ARENA
+                                      | MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_BINS
+                                      | MEMKIND_STAT_PRINT_OMIT_PER_SIZE_CLASS_LARGE
+                                      | MEMKIND_STAT_PRINT_OMIT_MUTEX
+                                      | MEMKIND_STAT_PRINT_OMIT_EXTENT);
+        memkind_free(kind, ptr);
+        memkind_destroy_kind(kind);
+        return ret;
+    } else if (strcmp(argv[1], "negative_test") == 0) {
+        fd = -1; // wrong file descriptor
+        return memkind_stats_print(&write_cb, (void *)&fd, MEMKIND_STAT_PRINT_ALL);
+    } else if (strcmp(argv[1], "opts_negative_test") == 0) {
+        int retcode = memkind_stats_print(NULL, NULL, 1024);
+        return retcode == MEMKIND_ERROR_INVALID ? MEMKIND_SUCCESS :
+               MEMKIND_ERROR_INVALID;
+    }
+
+    printf("Error: unknown parameter '%s'\n", argv[1]);
+    return -1;
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,7 +14,8 @@ GTEST_BINARIES=(all_tests decorator_test gb_page_tests_bind_policy \
                 memkind_stat_test defrag_reallocate background_threads_test memkind_highcapacity_test)
 
 # Pytest files executed by Berta
-PYTEST_FILES=(hbw_detection_test.py autohbw_test.py trace_mechanism_test.py max_bg_threads_env_var_test.py)
+PYTEST_FILES=(hbw_detection_test.py autohbw_test.py trace_mechanism_test.py max_bg_threads_env_var_test.py \
+              stats_print_test.py)
 
 red=`tput setaf 1`
 green=`tput setaf 2`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add to API function memkind_stats_print() which wraps over je_malloc_stats_print().

- [x] Documentation
- [x] All test cases

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [x] All newly added files have proprietary license (if necessary)
- [x] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/513)
<!-- Reviewable:end -->
