### PR TITLE
Add Codespell to Github Actions

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -17,6 +17,19 @@ jobs:
     - name: Run Astyle
       run: ./astyle.sh
 
+  codespell:
+    runs-on: ubuntu-20.04
+    name: Code Linting - Codespell
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: codespell-project/actions-codespell@master
+      with:
+        skip: ./jemalloc,./test/gtest_fused/gtest,./.github/workflows/gha.yml
+        ignore_words_list: "ue"
+
   building:
     runs-on: ${{ matrix.os }}
     name: Building memkind daxctl ${{ matrix.daxctl }} | hwloc ${{ matrix.hwloc }} | ${{ matrix.os }} | ${{ matrix.env.cc }}-${{ matrix.compiler_version }}


### PR DESCRIPTION
- exclude jemalloc/gtest dependency
- add ".UE" as Hypertext link macros
  (ref: https://man7.org/linux/man-pages/man7/man.7.html)
  to ignored words
- codespell supports only lowercase letters in ignored words

The intention is to limit typo(s),  like in a17bdaf

The effect of PR could be seen:
https://github.com/michalbiesek/memkind/actions/runs/541471559

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/517)
<!-- Reviewable:end -->
