### PR TITLE
Fix rpm build for openSUSE

### DIFF
--- a/memkind.spec.mk
+++ b/memkind.spec.mk
@@ -34,7 +34,7 @@ BuildRequires: numactl-devel
 
 %define daxctl_min_version 66
 %if %{defined suse_version}
-BuildRequires: libdaxctl-devel >= %{daxctl_min_version}
+BuildRequires: libndctl-devel >= %{daxctl_min_version}
 %else
 BuildRequires: daxctl-devel >= %{daxctl_min_version}
 %endif


### PR DESCRIPTION
- libndctl-devel is available instead of libdaxctl-devel
- ref: https://pkgs.org/download/libndctl-devel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/537)
<!-- Reviewable:end -->
