### PR TITLE
Fix typo in memkind3 manual

### DIFF
--- a/man/memkind.3
+++ b/man/memkind.3
@@ -78,7 +78,7 @@ This header expose STANDARD and EXPERIMENTAL API. API Standards are described be
 .br
 .BI "int memkind_get_stat(memkind_t " "kind" ", memkind_stat " "stat" ", size_t " "*value" );
 .br
-.BI "int memkind_stats_print(void " "(*write_cb) (void *, const char *)" ", void " "*cbopaque" ", memkind_stat_print_opt "opts" );
+.BI "int memkind_stats_print(void " "(*write_cb) (void *, const char *)" ", void " "*cbopaque" ", memkind_stat_print_opt " "opts" );
 .sp
 .B "DECORATORS:"
 .br


### PR DESCRIPTION
- remove redundant " in memkind_stats_print

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/539)
<!-- Reviewable:end -->
