### PR TITLE
Update clang-format configuration and disable the format for struct

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,6 +15,8 @@ BraceWrapping:
   AfterUnion: false
   BeforeCatch: false
   BeforeElse: false
+# Uncomment after switching to clang-format >= 11.0
+# BeforeWhile: false
   IndentBraces: false
   SplitEmptyFunction: false
 AlignConsecutiveMacros: true

--- a/include/memkind/internal/memkind_private.h
+++ b/include/memkind/internal/memkind_private.h
@@ -51,14 +51,13 @@ enum memkind_const_private
     MEMKIND_NAME_LENGTH_PRIV = 64
 };
 
+// clang-format off
 struct memkind_ops {
-    int (*create)(struct memkind *kind, struct memkind_ops *ops,
-                  const char *name);
+    int (*create)(struct memkind *kind, struct memkind_ops *ops, const char *name);
     int (*destroy)(struct memkind *kind);
     void *(*malloc)(struct memkind *kind, size_t size);
     void *(*calloc)(struct memkind *kind, size_t num, size_t size);
-    int (*posix_memalign)(struct memkind *kind, void **memptr, size_t alignment,
-                          size_t size);
+    int (*posix_memalign)(struct memkind *kind, void **memptr, size_t alignment, size_t size);
     void *(*realloc)(struct memkind *kind, void *ptr, size_t size);
     void (*free)(struct memkind *kind, void *ptr);
     void *(*mmap)(struct memkind *kind, void *addr, size_t size);
@@ -66,18 +65,17 @@ struct memkind_ops {
     int (*madvise)(struct memkind *kind, void *addr, size_t size);
     int (*get_mmap_flags)(struct memkind *kind, int *flags);
     int (*get_mbind_mode)(struct memkind *kind, int *mode);
-    int (*get_mbind_nodemask)(struct memkind *kind, unsigned long *nodemask,
-                              unsigned long maxnode);
+    int (*get_mbind_nodemask)(struct memkind *kind, unsigned long *nodemask, unsigned long maxnode);
     int (*get_arena)(struct memkind *kind, unsigned int *arena, size_t size);
     int (*check_available)(struct memkind *kind);
     void (*init_once)(void);
     int (*finalize)(struct memkind *kind);
     size_t (*malloc_usable_size)(struct memkind *kind, void *ptr);
-    int (*update_memory_usage_policy)(struct memkind *kind,
-                                      memkind_mem_usage_policy policy);
+    int (*update_memory_usage_policy)(struct memkind *kind, memkind_mem_usage_policy policy);
     int (*get_stat)(memkind_t kind, memkind_stat_type stat, size_t *value);
     void *(*defrag_reallocate)(struct memkind *kind, void *ptr);
 };
+// clang-format on
 
 struct memkind {
     struct memkind_ops *ops;

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -13,6 +13,7 @@ static struct heap_manager_ops *heap_manager_g;
 
 static pthread_once_t heap_manager_init_once_g = PTHREAD_ONCE_INIT;
 
+// clang-format off
 struct heap_manager_ops {
     void (*init)(struct memkind *kind);
     size_t (*heap_manager_malloc_usable_size)(void *ptr);
@@ -23,9 +24,7 @@ struct heap_manager_ops {
     int (*heap_manager_get_stat)(memkind_stat_type stat, size_t *value);
     void *(*heap_manager_defrag_reallocate)(void *ptr);
     int (*heap_manager_set_bg_threads)(bool state);
-    int (*heap_manager_stats_print)(void (*write_cb)(void *, const char *),
-                                    void *cbopaque,
-                                    memkind_stat_print_opt opts);
+    int (*heap_manager_stats_print)(void (*write_cb)(void *, const char *), void *cbopaque, memkind_stat_print_opt opts);
 };
 
 static struct heap_manager_ops arena_heap_manager_g = {
@@ -36,24 +35,24 @@ static struct heap_manager_ops arena_heap_manager_g = {
     .heap_manager_detect_kind = memkind_arena_detect_kind,
     .heap_manager_update_cached_stats = memkind_arena_update_cached_stats,
     .heap_manager_get_stat = memkind_arena_get_global_stat,
-    .heap_manager_defrag_reallocate =
-        memkind_arena_defrag_reallocate_with_kind_detect,
+    .heap_manager_defrag_reallocate = memkind_arena_defrag_reallocate_with_kind_detect,
     .heap_manager_set_bg_threads = memkind_arena_set_bg_threads,
-    .heap_manager_stats_print = memkind_arena_stats_print};
+    .heap_manager_stats_print = memkind_arena_stats_print
+};
 
 static struct heap_manager_ops tbb_heap_manager_g = {
     .init = tbb_initialize,
-    .heap_manager_malloc_usable_size =
-        tbb_pool_malloc_usable_size_with_kind_detect,
+    .heap_manager_malloc_usable_size = tbb_pool_malloc_usable_size_with_kind_detect,
     .heap_manager_free = tbb_pool_free_with_kind_detect,
     .heap_manager_realloc = tbb_pool_realloc_with_kind_detect,
     .heap_manager_detect_kind = tbb_detect_kind,
     .heap_manager_update_cached_stats = tbb_update_cached_stats,
     .heap_manager_get_stat = tbb_get_global_stat,
-    .heap_manager_defrag_reallocate =
-        tbb_pool_defrag_reallocate_with_kind_detect,
+    .heap_manager_defrag_reallocate = tbb_pool_defrag_reallocate_with_kind_detect,
     .heap_manager_set_bg_threads = tbb_set_bg_threads,
-    .heap_manager_stats_print = tbb_stats_print};
+    .heap_manager_stats_print = tbb_stats_print
+};
+// clang-format on
 
 static void set_heap_manager()
 {

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -39,33 +39,31 @@
 #include <sys/param.h>
 #include <unistd.h>
 
+// clang-format off
 #ifdef MEMKIND_ENABLE_HEAP_MANAGER
-#define m_detect_kind(ptr)             heap_manager_detect_kind(ptr)
-#define m_free(ptr)                    heap_manager_free(ptr)
-#define m_realloc(ptr, size)           heap_manager_realloc(ptr, size)
-#define m_usable_size(ptr)             heap_manager_malloc_usable_size(ptr)
-#define m_defrag_reallocate(ptr)       heap_manager_defrag_reallocate(ptr)
-#define m_get_global_stat(stat, value) heap_manager_get_stat(stat, value)
-#define m_update_cached_stats          heap_manager_update_cached_stats
-#define m_init                         heap_manager_init
-#define m_set_bg_threads(state)        heap_manager_set_bg_threads(state)
-#define m_stats_print(write_cb, cbopaque, opts)                                \
-    heap_manager_stats_print(write_cb, cbopaque, opts)
+#define m_detect_kind(ptr)                      heap_manager_detect_kind(ptr)
+#define m_free(ptr)                             heap_manager_free(ptr)
+#define m_realloc(ptr, size)                    heap_manager_realloc(ptr, size)
+#define m_usable_size(ptr)                      heap_manager_malloc_usable_size(ptr)
+#define m_defrag_reallocate(ptr)                heap_manager_defrag_reallocate(ptr)
+#define m_get_global_stat(stat, value)          heap_manager_get_stat(stat, value)
+#define m_update_cached_stats                   heap_manager_update_cached_stats
+#define m_init                                  heap_manager_init
+#define m_set_bg_threads(state)                 heap_manager_set_bg_threads(state)
+#define m_stats_print(write_cb, cbopaque, opts) heap_manager_stats_print(write_cb, cbopaque, opts)
 #else
-#define m_detect_kind(ptr)   memkind_arena_detect_kind(ptr)
-#define m_free(ptr)          memkind_arena_free_with_kind_detect(ptr)
-#define m_realloc(ptr, size) memkind_arena_realloc_with_kind_detect(ptr, size)
-#define m_usable_size(ptr)   memkind_default_malloc_usable_size(NULL, ptr)
-#define m_defrag_reallocate(ptr)                                               \
-    memkind_arena_defrag_reallocate_with_kind_detect(ptr)
-#define m_get_global_stat(stat, value)                                         \
-    memkind_arena_get_global_stat(stat, value)
-#define m_update_cached_stats   memkind_arena_update_cached_stats
-#define m_init                  memkind_arena_init
-#define m_set_bg_threads(state) memkind_arena_set_bg_threads(state)
-#define m_stats_print(write_cb, cbopaque, opts)                                \
-    memkind_arena_stats_print(write_cb, cbopaque, opts)
+#define m_detect_kind(ptr)                      memkind_arena_detect_kind(ptr)
+#define m_free(ptr)                             memkind_arena_free_with_kind_detect(ptr)
+#define m_realloc(ptr, size)                    memkind_arena_realloc_with_kind_detect(ptr, size)
+#define m_usable_size(ptr)                      memkind_default_malloc_usable_size(NULL, ptr)
+#define m_defrag_reallocate(ptr)                memkind_arena_defrag_reallocate_with_kind_detect(ptr)
+#define m_get_global_stat(stat, value)          memkind_arena_get_global_stat(stat, value)
+#define m_update_cached_stats                   memkind_arena_update_cached_stats
+#define m_init                                  memkind_arena_init
+#define m_set_bg_threads(state)                 memkind_arena_set_bg_threads(state)
+#define m_stats_print(write_cb, cbopaque, opts) memkind_arena_stats_print(write_cb, cbopaque, opts)
 #endif
+// clang-format on
 
 /* Clear bits in x, but only this specified in mask. */
 #define CLEAR_BIT(x, mask) ((x) &= (~(mask)))
@@ -258,49 +256,33 @@ static struct memkind MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_STATIC = {
     .init_once = PTHREAD_ONCE_INIT,
 };
 
+// clang-format off
 MEMKIND_EXPORT struct memkind *MEMKIND_DEFAULT = &MEMKIND_DEFAULT_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_HUGETLB = &MEMKIND_HUGETLB_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_INTERLEAVE = &MEMKIND_INTERLEAVE_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_HBW = &MEMKIND_HBW_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_HBW_ALL = &MEMKIND_HBW_ALL_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HBW_PREFERRED =
-    &MEMKIND_HBW_PREFERRED_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HBW_HUGETLB =
-    &MEMKIND_HBW_HUGETLB_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HBW_ALL_HUGETLB =
-    &MEMKIND_HBW_ALL_HUGETLB_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HBW_PREFERRED_HUGETLB =
-    &MEMKIND_HBW_PREFERRED_HUGETLB_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HBW_PREFERRED = &MEMKIND_HBW_PREFERRED_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HBW_HUGETLB = &MEMKIND_HBW_HUGETLB_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HBW_ALL_HUGETLB = &MEMKIND_HBW_ALL_HUGETLB_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HBW_PREFERRED_HUGETLB = &MEMKIND_HBW_PREFERRED_HUGETLB_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_HBW_GBTLB = &MEMKIND_HBW_GBTLB_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HBW_PREFERRED_GBTLB =
-    &MEMKIND_HBW_PREFERRED_GBTLB_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HBW_PREFERRED_GBTLB = &MEMKIND_HBW_PREFERRED_GBTLB_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_GBTLB = &MEMKIND_GBTLB_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HBW_INTERLEAVE =
-    &MEMKIND_HBW_INTERLEAVE_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HBW_INTERLEAVE = &MEMKIND_HBW_INTERLEAVE_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_REGULAR = &MEMKIND_REGULAR_STATIC;
 MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM = &MEMKIND_DAX_KMEM_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM_ALL =
-    &MEMKIND_DAX_KMEM_ALL_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM_PREFERRED =
-    &MEMKIND_DAX_KMEM_PREFERRED_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM_INTERLEAVE =
-    &MEMKIND_DAX_KMEM_INTERLEAVE_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY =
-    &MEMKIND_HIGHEST_CAPACITY_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY_PREFERRED =
-    &MEMKIND_HIGHEST_CAPACITY_PREFERRED_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY_LOCAL =
-    &MEMKIND_HIGHEST_CAPACITY_LOCAL_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED =
-    &MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_LOWEST_LATENCY_LOCAL =
-    &MEMKIND_LOWEST_LATENCY_LOCAL_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED =
-    &MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_BANDWIDTH_LOCAL =
-    &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_STATIC;
-MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED =
-    &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM_ALL = &MEMKIND_DAX_KMEM_ALL_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM_PREFERRED = &MEMKIND_DAX_KMEM_PREFERRED_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_DAX_KMEM_INTERLEAVE = &MEMKIND_DAX_KMEM_INTERLEAVE_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY = &MEMKIND_HIGHEST_CAPACITY_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY_PREFERRED = &MEMKIND_HIGHEST_CAPACITY_PREFERRED_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY_LOCAL = &MEMKIND_HIGHEST_CAPACITY_LOCAL_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED = &MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_LOWEST_LATENCY_LOCAL = &MEMKIND_LOWEST_LATENCY_LOCAL_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED = &MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_BANDWIDTH_LOCAL = &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_STATIC;
+MEMKIND_EXPORT struct memkind *MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED = &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_STATIC;
 
 struct memkind_registry {
     struct memkind *partition_map[MEMKIND_MAX_KIND];
@@ -314,12 +296,10 @@ static struct memkind_registry memkind_registry_g = {
         [MEMKIND_PARTITION_HBW] = &MEMKIND_HBW_STATIC,
         [MEMKIND_PARTITION_HBW_PREFERRED] = &MEMKIND_HBW_PREFERRED_STATIC,
         [MEMKIND_PARTITION_HBW_HUGETLB] = &MEMKIND_HBW_HUGETLB_STATIC,
-        [MEMKIND_PARTITION_HBW_PREFERRED_HUGETLB] =
-            &MEMKIND_HBW_PREFERRED_HUGETLB_STATIC,
+        [MEMKIND_PARTITION_HBW_PREFERRED_HUGETLB] = &MEMKIND_HBW_PREFERRED_HUGETLB_STATIC,
         [MEMKIND_PARTITION_HUGETLB] = &MEMKIND_HUGETLB_STATIC,
         [MEMKIND_PARTITION_HBW_GBTLB] = &MEMKIND_HBW_GBTLB_STATIC,
-        [MEMKIND_PARTITION_HBW_PREFERRED_GBTLB] =
-            &MEMKIND_HBW_PREFERRED_GBTLB_STATIC,
+        [MEMKIND_PARTITION_HBW_PREFERRED_GBTLB] = &MEMKIND_HBW_PREFERRED_GBTLB_STATIC,
         [MEMKIND_PARTITION_GBTLB] = &MEMKIND_GBTLB_STATIC,
         [MEMKIND_PARTITION_HBW_INTERLEAVE] = &MEMKIND_HBW_INTERLEAVE_STATIC,
         [MEMKIND_PARTITION_INTERLEAVE] = &MEMKIND_INTERLEAVE_STATIC,
@@ -328,28 +308,21 @@ static struct memkind_registry memkind_registry_g = {
         [MEMKIND_PARTITION_HBW_ALL_HUGETLB] = &MEMKIND_HBW_ALL_HUGETLB_STATIC,
         [MEMKIND_PARTITION_DAX_KMEM] = &MEMKIND_DAX_KMEM_STATIC,
         [MEMKIND_PARTITION_DAX_KMEM_ALL] = &MEMKIND_DAX_KMEM_ALL_STATIC,
-        [MEMKIND_PARTITION_DAX_KMEM_PREFERRED] =
-            &MEMKIND_DAX_KMEM_PREFERRED_STATIC,
-        [MEMKIND_PARTITION_DAX_KMEM_INTERLEAVE] =
-            &MEMKIND_DAX_KMEM_INTERLEAVE_STATIC,
+        [MEMKIND_PARTITION_DAX_KMEM_PREFERRED] = &MEMKIND_DAX_KMEM_PREFERRED_STATIC,
+        [MEMKIND_PARTITION_DAX_KMEM_INTERLEAVE] = &MEMKIND_DAX_KMEM_INTERLEAVE_STATIC,
         [MEMKIND_PARTITION_HIGHEST_CAPACITY] = &MEMKIND_HIGHEST_CAPACITY_STATIC,
-        [MEMKIND_PARTITION_HIGHEST_CAPACITY_PREFERRED] =
-            &MEMKIND_HIGHEST_CAPACITY_PREFERRED_STATIC,
-        [MEMKIND_PARTITION_HIGHEST_CAPACITY_LOCAL] =
-            &MEMKIND_HIGHEST_CAPACITY_LOCAL_STATIC,
-        [MEMKIND_PARTITION_HIGHEST_CAPACITY_LOCAL_PREFERRED] =
-            &MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED_STATIC,
-        [MEMKIND_PARTITION_LOWEST_LATENCY_LOCAL] =
-            &MEMKIND_LOWEST_LATENCY_LOCAL_STATIC,
-        [MEMKIND_PARTITION_LOWEST_LATENCY_LOCAL_PREFERRED] =
-            &MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED_STATIC,
-        [MEMKIND_PARTITION_HIGHEST_BANDWIDTH_LOCAL] =
-            &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_STATIC,
-        [MEMKIND_PARTITION_HIGHEST_BANDWIDTH_LOCAL_PREFERRED] =
-            &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_STATIC,
+        [MEMKIND_PARTITION_HIGHEST_CAPACITY_PREFERRED] = &MEMKIND_HIGHEST_CAPACITY_PREFERRED_STATIC,
+        [MEMKIND_PARTITION_HIGHEST_CAPACITY_LOCAL] =  &MEMKIND_HIGHEST_CAPACITY_LOCAL_STATIC,
+        [MEMKIND_PARTITION_HIGHEST_CAPACITY_LOCAL_PREFERRED] = &MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED_STATIC,
+        [MEMKIND_PARTITION_LOWEST_LATENCY_LOCAL] = &MEMKIND_LOWEST_LATENCY_LOCAL_STATIC,
+        [MEMKIND_PARTITION_LOWEST_LATENCY_LOCAL_PREFERRED] = &MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED_STATIC,
+        [MEMKIND_PARTITION_HIGHEST_BANDWIDTH_LOCAL] = &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_STATIC,
+        [MEMKIND_PARTITION_HIGHEST_BANDWIDTH_LOCAL_PREFERRED] = &MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_STATIC,
     },
     MEMKIND_NUM_BASE_KIND,
-    PTHREAD_MUTEX_INITIALIZER};
+    PTHREAD_MUTEX_INITIALIZER
+};
+// clang-format on
 
 void *kind_mmap(struct memkind *kind, void *addr, size_t size)
 {
@@ -396,29 +369,21 @@ struct create_args {
     memkind_memtype_t memtype_flags;
 };
 
+// clang-format off
 static struct create_args supported_args[] = {
 
-    {&MEMKIND_HBW_STATIC, MEMKIND_POLICY_BIND_LOCAL, 0,
-     MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_HBW_HUGETLB_STATIC, MEMKIND_POLICY_BIND_LOCAL,
-     MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_HBW_ALL_STATIC, MEMKIND_POLICY_BIND_ALL, 0,
-     MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_HBW_ALL_HUGETLB_STATIC, MEMKIND_POLICY_BIND_ALL,
-     MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_HBW_PREFERRED_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL, 0,
-     MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_HBW_PREFERRED_HUGETLB_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL,
-     MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_HBW_INTERLEAVE_STATIC, MEMKIND_POLICY_INTERLEAVE_ALL, 0,
-     MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
-    {&MEMKIND_DEFAULT_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL, 0,
-     MEMKIND_MEMTYPE_DEFAULT},
-    {&MEMKIND_HUGETLB_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL,
-     MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_DEFAULT},
-    {&MEMKIND_INTERLEAVE_STATIC, MEMKIND_POLICY_INTERLEAVE_ALL, 0,
-     MEMKIND_MEMTYPE_HIGH_BANDWIDTH | MEMKIND_MEMTYPE_DEFAULT},
+    {&MEMKIND_HBW_STATIC, MEMKIND_POLICY_BIND_LOCAL, 0, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_HBW_HUGETLB_STATIC, MEMKIND_POLICY_BIND_LOCAL, MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_HBW_ALL_STATIC, MEMKIND_POLICY_BIND_ALL, 0, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_HBW_ALL_HUGETLB_STATIC, MEMKIND_POLICY_BIND_ALL, MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_HBW_PREFERRED_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL, 0, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_HBW_PREFERRED_HUGETLB_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL, MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_HBW_INTERLEAVE_STATIC, MEMKIND_POLICY_INTERLEAVE_ALL, 0, MEMKIND_MEMTYPE_HIGH_BANDWIDTH},
+    {&MEMKIND_DEFAULT_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL, 0, MEMKIND_MEMTYPE_DEFAULT},
+    {&MEMKIND_HUGETLB_STATIC, MEMKIND_POLICY_PREFERRED_LOCAL, MEMKIND_MASK_PAGE_SIZE_2MB, MEMKIND_MEMTYPE_DEFAULT},
+    {&MEMKIND_INTERLEAVE_STATIC, MEMKIND_POLICY_INTERLEAVE_ALL, 0, MEMKIND_MEMTYPE_HIGH_BANDWIDTH | MEMKIND_MEMTYPE_DEFAULT},
 };
+// clang-format on
 
 /* Kind creation */
 MEMKIND_EXPORT int memkind_create_kind(memkind_memtype_t memtype_flags,

--- a/src/memkind_capacity.c
+++ b/src/memkind_capacity.c
@@ -164,7 +164,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_hi_cap_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_PREFERRED_OPS = {
     .create = memkind_arena_create,
@@ -184,4 +185,5 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_PREFERRED_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_hi_cap_preferred_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};

--- a/src/memkind_dax_kmem.c
+++ b/src/memkind_dax_kmem.c
@@ -211,7 +211,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_ALL_OPS = {
     .create = memkind_arena_create,
@@ -231,7 +232,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_ALL_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_PREFERRED_OPS = {
     .create = memkind_arena_create,
@@ -251,7 +253,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_PREFERRED_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_INTERLEAVE_OPS = {
     .create = memkind_arena_create,
@@ -271,4 +274,5 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_DAX_KMEM_INTERLEAVE_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};

--- a/src/memkind_default.c
+++ b/src/memkind_default.c
@@ -39,7 +39,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_DEFAULT_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_default_destroy,
     .get_stat = memkind_default_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT int memkind_default_create(struct memkind *kind,
                                           struct memkind_ops *ops,

--- a/src/memkind_gbtlb.c
+++ b/src/memkind_gbtlb.c
@@ -34,7 +34,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_GBTLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_GBTLB_OPS = {
     .create = memkind_arena_create,
@@ -55,7 +56,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_GBTLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_GBTLB_OPS = {
     .create = memkind_arena_create,
@@ -73,7 +75,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_GBTLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 #define ONE_GB 1073741824ULL
 

--- a/src/memkind_hbw.c
+++ b/src/memkind_hbw.c
@@ -43,7 +43,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_OPS = {
     .create = memkind_arena_create,
@@ -63,7 +64,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_HUGETLB_OPS = {
     .create = memkind_arena_create,
@@ -83,7 +85,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_HUGETLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_HUGETLB_OPS = {
     .create = memkind_arena_create,
@@ -103,7 +106,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_ALL_HUGETLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_OPS = {
     .create = memkind_arena_create,
@@ -123,7 +127,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_HUGETLB_OPS = {
     .create = memkind_arena_create,
@@ -143,7 +148,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_PREFERRED_HUGETLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_INTERLEAVE_OPS = {
     .create = memkind_arena_create,
@@ -164,7 +170,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HBW_INTERLEAVE_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 struct hbw_numanode_t {
     int init_err;

--- a/src/memkind_hugetlb.c
+++ b/src/memkind_hugetlb.c
@@ -36,7 +36,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HUGETLB_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 static int get_nr_overcommit_hugepages_cached(size_t pagesize, size_t *out);
 static int get_nr_hugepages_cached(size_t pagesize, struct bitmask *nodemask,

--- a/src/memkind_interleave.c
+++ b/src/memkind_interleave.c
@@ -24,7 +24,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_INTERLEAVE_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_arena_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT void memkind_interleave_init_once(void)
 {

--- a/src/memkind_local.c
+++ b/src/memkind_local.c
@@ -263,7 +263,7 @@ static void memkind_hi_bw_loc_preferred_init_once(void)
 {
     memkind_init(MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED, true);
 }
-
+// clang-format off
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_LOCAL_OPS = {
     .create = memkind_arena_create,
     .destroy = memkind_default_destroy,
@@ -282,27 +282,29 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_LOCAL_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_hi_cap_loc_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
-MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED_OPS =
-    {.create = memkind_arena_create,
-     .destroy = memkind_default_destroy,
-     .malloc = memkind_arena_malloc,
-     .calloc = memkind_arena_calloc,
-     .posix_memalign = memkind_arena_posix_memalign,
-     .realloc = memkind_arena_realloc,
-     .free = memkind_arena_free,
-     .check_available = memkind_loc_check_available,
-     .mbind = memkind_default_mbind,
-     .get_mmap_flags = memkind_default_get_mmap_flags,
-     .get_mbind_mode = memkind_preferred_get_mbind_mode,
-     .get_mbind_nodemask = memkind_hi_cap_loc_preferred_get_mbind_nodemask,
-     .get_arena = memkind_thread_get_arena,
-     .init_once = memkind_hi_cap_loc_preferred_init_once,
-     .malloc_usable_size = memkind_default_malloc_usable_size,
-     .finalize = memkind_hi_cap_loc_preferred_finalize,
-     .get_stat = memkind_arena_get_kind_stat,
-     .defrag_reallocate = memkind_arena_defrag_reallocate};
+MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_CAPACITY_LOCAL_PREFERRED_OPS = {
+    .create = memkind_arena_create,
+    .destroy = memkind_default_destroy,
+    .malloc = memkind_arena_malloc,
+    .calloc = memkind_arena_calloc,
+    .posix_memalign = memkind_arena_posix_memalign,
+    .realloc = memkind_arena_realloc,
+    .free = memkind_arena_free,
+    .check_available = memkind_loc_check_available,
+    .mbind = memkind_default_mbind,
+    .get_mmap_flags = memkind_default_get_mmap_flags,
+    .get_mbind_mode = memkind_preferred_get_mbind_mode,
+    .get_mbind_nodemask = memkind_hi_cap_loc_preferred_get_mbind_nodemask,
+    .get_arena = memkind_thread_get_arena,
+    .init_once = memkind_hi_cap_loc_preferred_init_once,
+    .malloc_usable_size = memkind_default_malloc_usable_size,
+    .finalize = memkind_hi_cap_loc_preferred_finalize,
+    .get_stat = memkind_arena_get_kind_stat,
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_LOWEST_LATENCY_LOCAL_OPS = {
     .create = memkind_arena_create,
@@ -322,7 +324,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_LOWEST_LATENCY_LOCAL_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_low_lat_loc_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED_OPS = {
     .create = memkind_arena_create,
@@ -342,7 +345,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_LOWEST_LATENCY_LOCAL_PREFERRED_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_low_lat_loc_preferred_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_BANDWIDTH_LOCAL_OPS = {
     .create = memkind_arena_create,
@@ -362,10 +366,10 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_BANDWIDTH_LOCAL_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_hi_bw_loc_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
-MEMKIND_EXPORT struct memkind_ops
-    MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_OPS = {
+MEMKIND_EXPORT struct memkind_ops MEMKIND_HIGHEST_BANDWIDTH_LOCAL_PREFERRED_OPS = {
         .create = memkind_arena_create,
         .destroy = memkind_default_destroy,
         .malloc = memkind_arena_malloc,
@@ -383,4 +387,6 @@ MEMKIND_EXPORT struct memkind_ops
         .malloc_usable_size = memkind_default_malloc_usable_size,
         .finalize = memkind_hi_bw_loc_preferred_finalize,
         .get_stat = memkind_arena_get_kind_stat,
-        .defrag_reallocate = memkind_arena_defrag_reallocate};
+        .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
+// clang-format on

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -37,7 +37,8 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_PMEM_OPS = {
     .finalize = memkind_pmem_destroy,
     .update_memory_usage_policy = memkind_arena_update_memory_usage_policy,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};
 
 void *pmem_extent_alloc(extent_hooks_t *extent_hooks, void *new_addr,
                         size_t size, size_t alignment, bool *zero, bool *commit,

--- a/src/memkind_regular.c
+++ b/src/memkind_regular.c
@@ -82,4 +82,5 @@ MEMKIND_EXPORT struct memkind_ops MEMKIND_REGULAR_OPS = {
     .malloc_usable_size = memkind_default_malloc_usable_size,
     .finalize = memkind_regular_finalize,
     .get_stat = memkind_arena_get_kind_stat,
-    .defrag_reallocate = memkind_arena_defrag_reallocate};
+    .defrag_reallocate = memkind_arena_defrag_reallocate,
+};


### PR DESCRIPTION
Ref: https://github.com/memkind/memkind/pull/516#pullrequestreview-596114979
The intention of this PR is to avoid breaking the line in sections like e.g.: struct

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/546)
<!-- Reviewable:end -->
