### PR TITLE
Don't use stdio buffers when logging.

### DIFF
--- a/tiering/memtier_log.c
+++ b/tiering/memtier_log.c
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 static const char *message_prefixes[MESSAGE_TYPE_MAX_VALUE] = {
     [MESSAGE_TYPE_ERROR] = "MEMKIND_MEM_TIERING_LOG_ERROR",
@@ -30,13 +31,22 @@ static pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void log_generic(message_type_t type, const char *format, va_list args)
 {
+    static char buf[4096], *b;
+
+    b = buf + sprintf(buf, "%s: ", message_prefixes[type]);
+    int blen = sizeof(buf) + (buf - b) - 1;
+    int len = vsnprintf(b, blen, format, args);
+    sprintf(b + len, "\n");
+    b += len + 1;
+
     if (pthread_mutex_lock(&log_lock) != 0) {
         assert(0 && "failed to acquire log mutex");
     }
 
-    fprintf(stderr, "%s: ", message_prefixes[type]);
-    vfprintf(stderr, format, args);
-    fprintf(stderr, "\n");
+    const char overflow_msg[] = "Warning: message truncated.\n";
+    if (len >= blen)
+        (void)!write(STDERR_FILENO, overflow_msg, sizeof(overflow_msg));
+    (void)!write(STDERR_FILENO, buf, b - buf);
 
     if (pthread_mutex_unlock(&log_lock) != 0) {
         assert(0 && "failed to release log mutex");


### PR DESCRIPTION
Instead of FILE output (which uses malloced memory), write directly to file descriptor.  This is done by glibc's `dprintf`.

All straightforward printf formats (or posibly even all) use a stack-alloced buffer.

No outside-visible changes: `fprintf(stderr)` already flushes after each call, which split the output into three pieces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/559)
<!-- Reviewable:end -->
