### PR TITLE
Fix typo in pmemallocator manpage

### DIFF
--- a/man/pmemallocator.3
+++ b/man/pmemallocator.3
@@ -16,7 +16,7 @@ functionality is considered as stable API (STANDARD API).
 .sp
 .BI "libmemkind::pmem::allocator(const char " "*dir" ", size_t " "max_size" );
 .br
-.BI "libmemkind::pmem::llocator(const char " "&dir" ", size_t " "max_size" ", libmemkind::allocation_policy " "alloc_policy" );
+.BI "libmemkind::pmem::allocator(const char " "&dir" ", size_t " "max_size" ", libmemkind::allocation_policy " "alloc_policy" );
 .br
 .BI "libmemkind::pmem::allocator(const std::string " "&dir" ", size_t " "max_size" );
 .br


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [x] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/569)
<!-- Reviewable:end -->
