### PR TITLE
Don't rely on python2 pytest.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -545,7 +545,7 @@ unit_tests_pmem: checkprogs
 
 unit_tests_hmat: checkprogs
 	test/hmat_test
-	pytest -s test/hbw_env_var_test.py
+	@pytest@ -s test/hbw_env_var_test.py
 
 unit_tests_dax_kmem: checkprogs
 	test/test_dax_kmem.sh

--- a/configure.ac
+++ b/configure.ac
@@ -297,6 +297,7 @@ if test "$CLANG_FORMAT" != ""; then
 fi
 AC_SUBST([clang_format], $CLANG_FORMAT)
 AM_CONDITIONAL([HAVE_CLANG_FORMAT], [test "x$clang_support" = xyes])
+AC_CHECK_PROGS(pytest, [pytest pytest-3], false)
 
 #============================cxx11=============================================
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -17,6 +17,10 @@ GTEST_BINARIES=(all_tests decorator_test gb_page_tests_bind_policy \
 PYTEST_FILES=(hbw_detection_test.py autohbw_test.py trace_mechanism_test.py max_bg_threads_env_var_test.py \
               stats_print_test.py)
 
+PYTEST=py.test
+which $PYTEST || PYTEST=py.test-3
+which $PYTEST || { echo >&2 "py.test not found"; exit 1; }
+
 red=`tput setaf 1`
 green=`tput setaf 2`
 yellow=`tput setaf 3`
@@ -100,7 +104,7 @@ function show_skipped_tests()
     for i in ${!PYTEST_FILES[*]}; do
         PTEST_BINARY_PATH=$TEST_PATH${PYTEST_FILES[$i]}
         IFS=$'\n'
-        for LINE in $(py.test $PTEST_BINARY_PATH --collect-only); do
+        for LINE in $($PYTEST $PTEST_BINARY_PATH --collect-only); do
             if [[ $LINE == *"<Class "* ]]; then
                 TEST_SUITE=$(sed "s/^.*'\(.*\)'.*$/\1/" <<< $LINE)
             elif [[ $LINE == *"<Function "* ]]; then
@@ -350,12 +354,12 @@ for i in ${!PYTEST_FILES[*]}; do
     emit
     emit "### Processing pytest file '$PTEST_BINARY_PATH' ###"
     IFS=$'\n'
-    for LINE in $(py.test $PTEST_BINARY_PATH --collect-only); do
+    for LINE in $($PYTEST $PTEST_BINARY_PATH --collect-only); do
         if [[ $LINE == *"<Class "* ]]; then
             TEST_SUITE=$(sed "s/^.*'\(.*\)'.*$/\1/" <<< $LINE)
         elif [[ $LINE == *"<Function "* ]]; then
             LINE=$(sed "s/^.*'\(.*\)'.*$/\1/" <<< $LINE)
-            TEST_CMD="py.test $PTEST_BINARY_PATH -k='%s' 2>&1"
+            TEST_CMD="$PYTEST $PTEST_BINARY_PATH -k='%s' 2>&1"
             execute_pytest "$TEST_CMD" "$TEST_SUITE" "$LINE"
             ret=$?
             if [ $err -eq 0 ]; then err=$ret; fi


### PR DESCRIPTION
Debian Bullseye doesn't ship unversioned names for Python 3 (to avoid unobvious breaks in non-ported scripts).  Thus, let's use `py.test-3` when needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/582)
<!-- Reviewable:end -->
