### PR TITLE
Use hash table for counter allocated size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,14 +313,14 @@ if test "x$memkind_c11_atomics" = "x1" ; then
 fi
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],[[
 int v = 8;
-__atomic_add_fetch(&v, 1, __ATOMIC_RELAXED);
+__atomic_fetch_add(&v, 1, __ATOMIC_RELAXED);
 ]])], [memkind_atomic_builtins="1"], [memkind_atomic_builtins="0"])
 if test "x$memkind_atomic_builtins" = "x1" ; then
   AC_DEFINE([MEMKIND_ATOMIC_BUILTINS_SUPPORT], [1], [__atomic_c* compiler builtins are supported])
 fi
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],[[
 int v = 8;
-__sync_add_and_fetch(&v, 1);
+__sync_fetch_and_add(&v, 1);
 ]])], [memkind_sync_fetch="1"], [memkind_sync_fetch="0"])
 if test "x$memkind_sync_fetch" = "x1" ; then
   AC_DEFINE([MEMKIND_ATOMIC_SYNC_SUPPORT], [1], [__sync_* compiler builtins are supported])

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -42,7 +42,7 @@
     __sync_sub_and_fetch(&counter, val)
 #define memkind_atomic_get(src, dest)                                          \
     do {                                                                       \
-        dest = __sync_sub_and_fetch(&src, 0)                                   \
+        dest = __sync_sub_and_fetch(&src, 0);                                  \
     } while (0)
 #else
 #error "Missing atomic implementation."

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -28,18 +28,18 @@
     } while (0)
 #elif defined(MEMKIND_ATOMIC_BUILTINS_SUPPORT)
 #define memkind_atomic_increment(counter, val)                                 \
-    __atomic_add_fetch(&counter, val, __ATOMIC_RELAXED)
+    __atomic_fetch_add(&counter, val, __ATOMIC_RELAXED)
 #define memkind_atomic_decrement(counter, val)                                 \
-    __atomic_sub_fetch(&counter, val, __ATOMIC_RELAXED)
+    __atomic_fetch_sub(&counter, val, __ATOMIC_RELAXED)
 #define memkind_atomic_get(src, dest)                                          \
     do {                                                                       \
         dest = __atomic_load_n(&src, __ATOMIC_RELAXED);                        \
     } while (0)
 #elif defined(MEMKIND_ATOMIC_SYNC_SUPPORT)
 #define memkind_atomic_increment(counter, val)                                 \
-    __sync_add_and_fetch(&counter, val)
+    __sync_fetch_and_add(&counter, val)
 #define memkind_atomic_decrement(counter, val)                                 \
-    __sync_sub_and_fetch(&counter, val)
+    __sync_fetch_and_sub(&counter, val)
 #define memkind_atomic_get(src, dest)                                          \
     do {                                                                       \
         dest = __sync_sub_and_fetch(&src, 0);                                  \

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -29,6 +29,8 @@
     do {                                                                       \
         dest = atomic_load_explicit(&src, memory_order_relaxed);               \
     } while (0)
+#define memkind_atomic_get_and_zeroing(src)                                    \
+    atomic_exchange_explicit(&src, 0, memory_order_relaxed)
 #elif defined(MEMKIND_ATOMIC_BUILTINS_SUPPORT)
 #define memkind_atomic_increment(counter, val)                                 \
     __atomic_fetch_add(&counter, val, __ATOMIC_RELAXED)
@@ -40,6 +42,8 @@
     do {                                                                       \
         dest = __atomic_load_n(&src, __ATOMIC_RELAXED);                        \
     } while (0)
+#define memkind_atomic_get_and_zeroing(src)                                    \
+    __atomic_exchange_n(&src, 0, __ATOMIC_RELAXED)
 #elif defined(MEMKIND_ATOMIC_SYNC_SUPPORT)
 #define memkind_atomic_increment(counter, val)                                 \
     __sync_fetch_and_add(&counter, val)
@@ -48,6 +52,10 @@
 #define memkind_atomic_get(src, dest)                                          \
     do {                                                                       \
         dest = __sync_sub_and_fetch(&src, 0);                                  \
+    } while (0)
+#define memkind_atomic_get_and_zeroing(src)                                    \
+    do {                                                                       \
+        dest = __sync_fetch_and_sub(&src, &src);                               \
     } while (0)
 #define memkind_atomic_set(counter, val)                                       \
     __atomic_store_n(&counter, val, __ATOMIC_RELAXED)
@@ -103,16 +111,19 @@ struct memtier_memory {
     void (*update_cfg)(struct memtier_memory *memory);
 };
 
-#define THREAD_BUCKETS (256U)
+#define THREAD_BUCKETS  (256U)
+#define FLUSH_THRESHOLD (51200)
 
-static MEMKIND_ATOMIC size_t kind_alloc_size[MEMKIND_MAX_KIND][THREAD_BUCKETS];
+static MEMKIND_ATOMIC long long t_alloc_size[MEMKIND_MAX_KIND][THREAD_BUCKETS];
+static MEMKIND_ATOMIC size_t g_alloc_size[MEMKIND_MAX_KIND];
 
 void memtier_reset_size(unsigned kind_id)
 {
     unsigned bucket_id;
     for (bucket_id = 0; bucket_id < THREAD_BUCKETS; ++bucket_id) {
-        memkind_atomic_set(kind_alloc_size[kind_id][bucket_id], 0);
+        memkind_atomic_set(t_alloc_size[kind_id][bucket_id], 0);
     }
+    memkind_atomic_set(g_alloc_size[kind_id], 0);
 }
 
 // SplitMix64 hash
@@ -128,13 +139,23 @@ static inline unsigned t_hash_64(void)
 static inline void increment_alloc_size(unsigned kind_id, size_t size)
 {
     unsigned bucket_id = t_hash_64();
-    memkind_atomic_increment(kind_alloc_size[kind_id][bucket_id], size);
+    if ((memkind_atomic_increment(t_alloc_size[kind_id][bucket_id], size) +
+         size) > FLUSH_THRESHOLD) {
+        size_t size_f =
+            memkind_atomic_get_and_zeroing(t_alloc_size[kind_id][bucket_id]);
+        memkind_atomic_increment(g_alloc_size[kind_id], size_f);
+    }
 }
 
 static inline void decrement_alloc_size(unsigned kind_id, size_t size)
 {
     unsigned bucket_id = t_hash_64();
-    memkind_atomic_decrement(kind_alloc_size[kind_id][bucket_id], size);
+    if ((memkind_atomic_decrement(t_alloc_size[kind_id][bucket_id], size) -
+         size) < -FLUSH_THRESHOLD) {
+        long long size_f =
+            memkind_atomic_get_and_zeroing(t_alloc_size[kind_id][bucket_id]);
+        memkind_atomic_increment(g_alloc_size[kind_id], size_f);
+    }
 }
 
 static memkind_t memtier_single_get_kind(struct memtier_memory *memory,
@@ -149,12 +170,13 @@ memtier_policy_static_threshold_get_kind(struct memtier_memory *memory,
 {
     struct memtier_tier_cfg *cfg = memory->cfg;
 
+    size_t size_tier, size_0;
     int i;
     int dest_tier = 0;
-    size_t size_0 = memtier_kind_allocated_size(cfg[0].kind);
+    memkind_atomic_get(g_alloc_size[cfg[0].kind->partition], size_0);
     for (i = 1; i < memory->size; ++i) {
-        if ((memtier_kind_allocated_size(cfg[i].kind) * cfg[i].kind_ratio) <
-            size_0) {
+        memkind_atomic_get(g_alloc_size[cfg[i].kind->partition], size_tier);
+        if ((size_tier * cfg[i].kind_ratio) < size_0) {
             dest_tier = i;
         }
     }
@@ -186,6 +208,7 @@ memtier_policy_dynamic_threshold_update_config(struct memtier_memory *memory)
     struct memtier_tier_cfg *cfg = memory->cfg;
     struct memtier_threshold_cfg *thres = memory->thres;
     int i;
+    size_t prev_alloc_size, next_alloc_size;
 
     // do the ratio checks only every each THRESHOLD_CHECK_CNT
     if (--memory->thres_check_cnt > 0) {
@@ -195,9 +218,13 @@ memtier_policy_dynamic_threshold_update_config(struct memtier_memory *memory)
     // for every pair of adjacent tiers, check if distance between actual vs
     // desired ratio between them is above TRIGGER level and if so, change
     // threshold by CHANGE_VAL
+    // TODO optimize the loop to avoid redundant atomic_get in 3 or more tier
+    // scenario
     for (i = 0; i < THRESHOLD_NUM(memory); ++i) {
-        size_t prev_alloc_size = memtier_kind_allocated_size(cfg[i].kind);
-        size_t next_alloc_size = memtier_kind_allocated_size(cfg[i + 1].kind);
+        memkind_atomic_get(g_alloc_size[cfg[i].kind->partition],
+                           prev_alloc_size);
+        memkind_atomic_get(g_alloc_size[cfg[i + 1].kind->partition],
+                           next_alloc_size);
 
         float current_ratio = -1;
         if (prev_alloc_size > 0) {
@@ -492,13 +519,17 @@ MEMKIND_EXPORT void memtier_free(void *ptr)
 
 MEMKIND_EXPORT size_t memtier_kind_allocated_size(memkind_t kind)
 {
-    size_t size_all = 0;
-    size_t size;
+    size_t size_ret;
+    long long size_all = 0;
+    long long size;
     unsigned bucket_id;
 
     for (bucket_id = 0; bucket_id < THREAD_BUCKETS; ++bucket_id) {
-        memkind_atomic_get(kind_alloc_size[kind->partition][bucket_id], size);
+        size = memkind_atomic_get_and_zeroing(
+            t_alloc_size[kind->partition][bucket_id]);
         size_all += size;
     }
-    return size_all;
+    size_ret =
+        memkind_atomic_increment(g_alloc_size[kind->partition], size_all);
+    return (size_ret + size_all);
 }

--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -48,6 +48,13 @@ protected:
             memtier_kind_allocated_size(MEMKIND_REGULAR);
     }
 
+    double allocation_ratio()
+    {
+        return static_cast<double>(
+                   memtier_kind_allocated_size(MEMKIND_DEFAULT)) /
+            static_cast<double>(memtier_kind_allocated_size(MEMKIND_REGULAR));
+    }
+
     void SetUp()
     {
         struct memtier_builder *builder = memtier_builder_new();
@@ -691,86 +698,73 @@ TEST_F(MemkindMemtierMemoryTest, test_ratio_basic)
 {
     std::vector<void *> allocs;
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    // actual ratio 1:1, desired 1:4
-    ASSERT_EQ(16ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(16ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    // desired ratio is 1:4 (0.25)
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    ASSERT_DOUBLE_EQ(allocation_ratio(), 1);
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    // actual ratio 1:2, desired 1:4
-    ASSERT_EQ(16ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(32ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    ASSERT_DOUBLE_EQ(allocation_ratio(), 0.5);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    // actual ratio 1:3, desired 1:4
-    ASSERT_EQ(16ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(48ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.33, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 8));
-    // actual ratio 1:3.5, desired 1:4
-    ASSERT_EQ(16ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(56ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 80 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.28, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    // actual ratio 1:4.5, desired 1:4
-    ASSERT_EQ(16ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(72ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.22, 0.01);
+    // next allocation should heighten ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    // actual ratio 1:2.25, desired 1:4
-    ASSERT_EQ(32ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(72ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.44, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 36));
-    // actual ratio 1:3.75, desired 1:4
-    ASSERT_EQ(32ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(120ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 360 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.28, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 8));
-    // actual ratio 1:4, desired 1:4
-    ASSERT_EQ(32ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(128ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 80 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.27, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 16));
-    // actual ratio 1:2.6, desired 1:4
-    ASSERT_EQ(48ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(128ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 160 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.23, 0.01);
+    // next allocation should heighten ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 128));
-    // actual ratio 1:5.3, desired 1:4
-    ASSERT_EQ(48ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(256ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 1280 * KB));
+    ASSERT_NEAR(allocation_ratio(), 1.19, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 256));
-    // actual ratio 1:0.842, desired 1:4
-    ASSERT_EQ(304ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(256ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 2560 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.40, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 512));
-    // actual ratio 1:2.526, desired 1:4
-    ASSERT_EQ(304ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(768ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 5 * MB));
+    ASSERT_NEAR(allocation_ratio(), 0.17, 0.01);
+    // next allocation should heighten ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 1024));
-    // actual ratio 1:5.894, desired 1:4
-    ASSERT_EQ(304ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(1792ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 7 * MB));
+    ASSERT_NEAR(allocation_ratio(), 0.97, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 160));
-    // actual ratio 1:3.862, desired 1:4
-    ASSERT_EQ(464ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(1792ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 1600 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.81, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 256));
-    // actual ratio 1:4.413, desired 1:4
-    ASSERT_EQ(464ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(2048ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 3 * MB));
+    ASSERT_NEAR(allocation_ratio(), 0.63, 0.01);
+    // next allocation should lower ratio
 
-    allocs.push_back(memtier_malloc(m_tier_memory, 48));
-    // actual ratio 1:4, desired 1:4
-    ASSERT_EQ(512ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
-    ASSERT_EQ(2048ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
+    allocs.push_back(memtier_malloc(m_tier_memory, 1 * MB));
+    ASSERT_NEAR(allocation_ratio(), 0.5879, 0.01);
+    // next allocation should lower ratio
+
+    allocs.push_back(memtier_malloc(m_tier_memory, 2560 * KB));
+    ASSERT_NEAR(allocation_ratio(), 0.5, 0.01);
 
     for (auto const &ptr : allocs) {
         memtier_free(ptr);

--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -968,7 +968,7 @@ TEST_F(MemkindMemtierThresholdTest, test_const_alloc_size)
     // Start checking distance between actual and desired ratio
     // after "ratio_check_skip" allocations
     const unsigned ratio_check_skip = 1000;
-    const float max_ratio_distance = 0.35; // 35%
+    const float max_ratio_distance = 0.41; // 41%
 
     for (unsigned i = 0; i < num_allocs; ++i) {
         void *ptr = memtier_malloc(m_tier_memory, alloc_size);
@@ -1024,7 +1024,7 @@ TEST_F(MemkindMemtierThresholdTest, test_various_alloc_size)
     }
 
     // check if actual ratios between tiers are close to desired
-    const float max_ratio_distance = 0.25; // 25%
+    const float max_ratio_distance = 0.32; // 32%
 
     size_t default_alloc_size = memtier_kind_allocated_size(MEMKIND_DEFAULT);
     size_t regular_alloc_size = memtier_kind_allocated_size(MEMKIND_REGULAR);


### PR DESCRIPTION
- reduce the overhead of access same counter variable by multiple threads simultaneously
- calculate hash based on thread_id
- provide atomic store implementation
- export atomic API to static functions


- [ ] Find the optimum value for buckets - make it configurable?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/621)
<!-- Reviewable:end -->
