### PR TITLE
Change return type in constructing memtier memory

### DIFF
--- a/include/memkind_memtier.h
+++ b/include/memkind_memtier.h
@@ -74,12 +74,10 @@ int memtier_builder_set_policy(struct memtier_builder *builder,
 /// \brief Construct a memtier memory
 /// \note STANDARD API
 /// \param builder memtier builder
-/// \param memory pointer to memtier memory which will be created
-/// \return Operation status, 0 on success, other values on
-/// failure
+/// \return Pointer to constructed memtier memory object
 ///
-int memtier_builder_construct_memtier_memory(struct memtier_builder *builder,
-                                             struct memtier_memory **memory);
+struct memtier_memory *
+memtier_builder_construct_memtier_memory(struct memtier_builder *builder);
 
 ///
 /// \brief Delete memtier memory

--- a/man/memkind_memtier.3
+++ b/man/memkind_memtier.3
@@ -24,7 +24,7 @@ functionality is considered as stable API (STANDARD API).
 .br
 .BI "int memtier_builder_set_policy(struct memtier_builder " "*builder" ", memtier_policy_t " "policy" );
 .br
-.BI "int memtier_builder_construct_memtier_memory(struct memtier_builder " "*builder" ", struct memtier_memory " "**memory" );
+.BI "struct memtier_memory *memtier_builder_construct_memtier_memory(struct memtier_builder " "*builder" );
 .br
 .BI "void memtier_delete_memtier_memory(struct memtier_memory " "*memory" );
 .sp

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -156,47 +156,47 @@ static inline memkind_t get_kind(struct memtier_memory *memory)
     return NULL;
 }
 
-MEMKIND_EXPORT int
-memtier_builder_construct_memtier_memory(struct memtier_builder *builder,
-                                         struct memtier_memory **memory)
+MEMKIND_EXPORT struct memtier_memory *
+memtier_builder_construct_memtier_memory(struct memtier_builder *builder)
 {
     unsigned i;
+    struct memtier_memory *memory;
+
     if (builder->size == 0) {
         log_err("No tier in builder.");
-        return -1;
+        return NULL;
     }
 
-    *memory = jemk_malloc(sizeof(struct memtier_memory));
-    if (!*memory) {
+    memory = jemk_malloc(sizeof(struct memtier_memory));
+    if (!memory) {
         log_err("malloc() failed.");
-        return -1;
+        return NULL;
     }
 
     // perform deep copy but store normalized (to kind[0]) ratio instead of
     // original
-    (*memory)->cfg =
-        jemk_calloc(builder->size, sizeof(struct memtier_tier_cfg));
-    if (!(*memory)->cfg) {
+    memory->cfg = jemk_calloc(builder->size, sizeof(struct memtier_tier_cfg));
+    if (!memory->cfg) {
         log_err("calloc() failed.");
         goto failure_calloc;
     }
 
     for (i = 1; i < builder->size; ++i) {
-        (*memory)->cfg[i].kind = builder->cfg[i].kind;
-        (*memory)->cfg[i].kind_ratio =
+        memory->cfg[i].kind = builder->cfg[i].kind;
+        memory->cfg[i].kind_ratio =
             builder->cfg[0].kind_ratio / builder->cfg[i].kind_ratio;
     }
-    (*memory)->cfg[0].kind = builder->cfg[0].kind;
-    (*memory)->cfg[0].kind_ratio = 1.0;
+    memory->cfg[0].kind = builder->cfg[0].kind;
+    memory->cfg[0].kind_ratio = 1.0;
 
-    (*memory)->size = builder->size;
-    (*memory)->policy = builder->policy;
-    return 0;
+    memory->size = builder->size;
+    memory->policy = builder->policy;
+    return memory;
 
 failure_calloc:
-    jemk_free(*memory);
+    jemk_free(memory);
 
-    return -1;
+    return NULL;
 }
 
 MEMKIND_EXPORT void memtier_delete_memtier_memory(struct memtier_memory *memory)

--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -45,8 +45,8 @@ protected:
         res = memtier_builder_set_policy(builder,
                                          MEMTIER_POLICY_STATIC_THRESHOLD);
         ASSERT_EQ(0, res);
-        res = memtier_builder_construct_memtier_memory(builder, &m_tier_memory);
-        ASSERT_EQ(0, res);
+        m_tier_memory = memtier_builder_construct_memtier_memory(builder);
+        ASSERT_NE(nullptr, m_tier_memory);
         memtier_builder_delete(builder);
     }
 
@@ -89,8 +89,8 @@ protected:
         res = memtier_builder_set_policy(builder,
                                          MEMTIER_POLICY_STATIC_THRESHOLD);
         ASSERT_EQ(0, res);
-        res = memtier_builder_construct_memtier_memory(builder, &m_tier_memory);
-        ASSERT_EQ(0, res);
+        m_tier_memory = memtier_builder_construct_memtier_memory(builder);
+        ASSERT_NE(nullptr, m_tier_memory);
         memtier_builder_delete(builder);
     }
 
@@ -148,8 +148,8 @@ TEST_F(MemkindMemtierTest, test_tier_construct_failure_zero_tiers)
     int res =
         memtier_builder_set_policy(builder, MEMTIER_POLICY_STATIC_THRESHOLD);
     ASSERT_EQ(0, res);
-    res = memtier_builder_construct_memtier_memory(builder, &tier_kind);
-    ASSERT_NE(0, res);
+    tier_kind = memtier_builder_construct_memtier_memory(builder);
+    ASSERT_EQ(nullptr, tier_kind);
     memtier_builder_delete(builder);
 }
 

--- a/tiering/ctl.c
+++ b/tiering/ctl.c
@@ -291,8 +291,8 @@ struct memtier_memory *ctl_create_tier_memory_from_env(char *env_var_string)
         goto cleanup_after_failure;
     }
 
-    ret = memtier_builder_construct_memtier_memory(builder, &tier_memory);
-    if (ret != 0) {
+    tier_memory = memtier_builder_construct_memtier_memory(builder);
+    if (!tier_memory) {
         goto cleanup_after_failure;
     }
 


### PR DESCRIPTION
- change return type of memtier_builder_construct_memtier_memory()
API function from int to a memtier_memory pointer

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/622)
<!-- Reviewable:end -->
