### PR TITLE
[RFC]Extend memtier_free with kind parameter

### DIFF
--- a/include/memkind_memtier.h
+++ b/include/memkind_memtier.h
@@ -194,11 +194,22 @@ int memtier_kind_posix_memalign(memkind_t kind, void **memptr, size_t alignment,
 size_t memtier_usable_size(void *ptr);
 
 ///
+/// \brief Free the memory space allocated with the memtier_kind API
+/// \note STANDARD API
+/// \param kind specified memkind kind
+/// \param ptr pointer to the allocated memory
+///
+void memtier_kind_free(memkind_t kind, void *ptr);
+
+///
 /// \brief Free the memory space allocated with the memtier API
 /// \note STANDARD API
 /// \param ptr pointer to the allocated memory
 ///
-void memtier_free(void *ptr);
+static inline void memtier_free(void *ptr)
+{
+    memtier_kind_free(NULL, ptr);
+}
 
 ///
 /// \brief Obtain size of allocated memory with the memtier API inside

--- a/man/memkind_memtier.3
+++ b/man/memkind_memtier.3
@@ -50,6 +50,8 @@ functionality is considered as stable API (STANDARD API).
 .br
 .BI "void memtier_free(void " "*ptr" );
 .br
+.BI "void memtier_kind_free(memkind_t " "kind" ", void " "*ptr" );
+.br
 .BI "size_t memtier_kind_allocated_size(memkind_t " "kind" );
 .sp
 .sp

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -508,11 +508,13 @@ MEMKIND_EXPORT size_t memtier_usable_size(void *ptr)
     return jemk_malloc_usable_size(ptr);
 }
 
-MEMKIND_EXPORT void memtier_free(void *ptr)
+MEMKIND_EXPORT void memtier_kind_free(memkind_t kind, void *ptr)
 {
-    memkind_t kind = memkind_detect_kind(ptr);
-    if (!kind)
-        return;
+    if (!kind) {
+        kind = memkind_detect_kind(ptr);
+        if (!kind)
+            return;
+    }
     decrement_alloc_size(kind->partition, jemk_malloc_usable_size(ptr));
     memkind_free(kind, ptr);
 }

--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -189,18 +189,18 @@ TEST_F(MemkindMemtierTest, test_tier_allocate)
     void *ptr = memtier_kind_malloc(MEMKIND_DEFAULT, size);
     ASSERT_NE(nullptr, ptr);
     ASSERT_EQ(MEMKIND_DEFAULT, memkind_detect_kind(ptr));
-    memtier_free(ptr);
+    memtier_kind_free(MEMKIND_DEFAULT, ptr);
     ptr = memtier_kind_calloc(MEMKIND_DEFAULT, size, size);
     ASSERT_NE(nullptr, ptr);
     ASSERT_EQ(MEMKIND_DEFAULT, memkind_detect_kind(ptr));
     void *new_ptr = memtier_kind_realloc(MEMKIND_DEFAULT, ptr, size);
     ASSERT_NE(nullptr, new_ptr);
     ASSERT_EQ(MEMKIND_DEFAULT, memkind_detect_kind(ptr));
-    memtier_free(new_ptr);
+    memtier_kind_free(MEMKIND_DEFAULT, new_ptr);
     int err = memtier_kind_posix_memalign(MEMKIND_DEFAULT, &ptr, 64, 32);
     ASSERT_EQ(0, err);
     ASSERT_EQ(MEMKIND_DEFAULT, memkind_detect_kind(ptr));
-    memtier_free(ptr);
+    memtier_kind_free(MEMKIND_DEFAULT, ptr);
 }
 
 TEST_F(MemkindMemtierTest, test_tier_builder_failure)
@@ -230,6 +230,8 @@ TEST_F(MemkindMemtierTest, test_tier_builder_set_policy_failure)
 TEST_F(MemkindMemtierTest, test_tier_free_nullptr)
 {
     for (int i = 0; i < 512; i++) {
+        memtier_kind_free(MEMKIND_DEFAULT, nullptr);
+        memtier_kind_free(nullptr, nullptr);
         memtier_free(nullptr);
     }
 }
@@ -378,10 +380,10 @@ TEST_F(MemkindMemtierMemoryTest, test_tier_check_size_malloc)
     ASSERT_EQ(reg_counter, memtier_kind_allocated_size(MEMKIND_REGULAR));
 
     for (auto const &ptr : def_vec) {
-        memtier_free(ptr);
+        memtier_kind_free(nullptr, ptr);
     }
     for (auto const &ptr : reg_vec) {
-        memtier_free(ptr);
+        memtier_kind_free(nullptr, ptr);
     }
     ASSERT_EQ(0ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
     ASSERT_EQ(0ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
@@ -567,10 +569,10 @@ TEST_F(MemkindMemtierMemoryTest, test_tier_kind_check_size_realloc_kind)
     ASSERT_EQ(reg_counter, memtier_kind_allocated_size(MEMKIND_REGULAR));
 
     for (auto const &ptr : def_vec) {
-        memtier_free(ptr);
+        memtier_kind_free(MEMKIND_DEFAULT, ptr);
     }
     for (auto const &ptr : reg_vec) {
-        memtier_free(ptr);
+        memtier_kind_free(MEMKIND_REGULAR, ptr);
     }
     ASSERT_EQ(0ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));
     ASSERT_EQ(0ULL, memtier_kind_allocated_size(MEMKIND_REGULAR));
@@ -636,10 +638,10 @@ TEST_F(MemkindMemtierMemoryTest,
     ASSERT_EQ(reg_counter, memtier_kind_allocated_size(MEMKIND_REGULAR));
 
     for (auto const &ptr : def_vec) {
-        memtier_free(ptr);
+        memtier_kind_free(MEMKIND_DEFAULT, ptr);
     }
     for (auto const &ptr : reg_vec) {
-        memtier_free(ptr);
+        memtier_kind_free(MEMKIND_REGULAR, ptr);
     }
 
     ASSERT_EQ(0ULL, memtier_kind_allocated_size(MEMKIND_DEFAULT));


### PR DESCRIPTION
- kind parameter will be used as a hint for optimization to
  avoid detecting kind operation
- memory allocated by memtier_kind and memtier API
  (malloc/calloc/realloc/posix_memalign) could be
  freed using memtier_free call

I am not sure about the naming convention should it be with a kind prefix or not. I Don't want to add two separate functions for "memtier" and for "memtier_kind" API. On the other side, I want to avoid confusion that **memtier_free** is designated only for "memtier_*alloc" API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/627)
<!-- Reviewable:end -->
