### PR TITLE
Modify memtier API - builder

### DIFF
--- a/include/memkind_memtier.h
+++ b/include/memkind_memtier.h
@@ -41,9 +41,10 @@ typedef enum memtier_policy_t
 ///
 /// \brief Create a memtier builder
 /// \note STANDARD API
+/// \param policy memtier policy
 /// \return memtier builder, NULL on failure
 ///
-struct memtier_builder *memtier_builder_new(void);
+struct memtier_builder *memtier_builder_new(memtier_policy_t policy);
 
 ///
 /// \brief Delete memtier builder
@@ -63,17 +64,6 @@ void memtier_builder_delete(struct memtier_builder *builder);
 ///
 int memtier_builder_add_tier(struct memtier_builder *builder, memkind_t kind,
                              unsigned kind_ratio);
-
-///
-/// \brief Set memtier policy to memtier builder
-/// \note STANDARD API
-/// \param builder memtier builder
-/// \param policy memtier policy
-/// \return Operation status, 0 on success, other values on
-/// failure
-///
-int memtier_builder_set_policy(struct memtier_builder *builder,
-                               memtier_policy_t policy);
 
 ///
 /// \brief Construct a memtier memory

--- a/man/memkind_memtier.3
+++ b/man/memkind_memtier.3
@@ -16,13 +16,11 @@ functionality is considered as stable API (STANDARD API).
 .sp
 .B "TIER MANAGEMENT:"
 .sp
-.BI "struct memtier_builder *memtier_builder_new(void);"
+.BI "struct memtier_builder *memtier_builder_new(memtier_policy_t " "policy" );
 .br
 .BI "void memtier_builder_delete(struct memtier_builder " "*builder" );
 .br
 .BI "int memtier_builder_add_tier(struct memtier_builder " "*builder" ", memkind_t " "kind" ", unsigned " "kind_ratio" );
-.br
-.BI "int memtier_builder_set_policy(struct memtier_builder " "*builder" ", memtier_policy_t " "policy" );
 .br
 .BI "struct memtier_memory *memtier_builder_construct_memtier_memory(struct memtier_builder " "*builder" );
 .br

--- a/utils/memtier_counter_bench/memtier_counter_bench.cpp
+++ b/utils/memtier_counter_bench/memtier_counter_bench.cpp
@@ -97,10 +97,8 @@ class memtier_bench_alloc: public counter_bench_alloc
 public:
     memtier_bench_alloc()
     {
-        m_tier_builder = memtier_builder_new();
+        m_tier_builder = memtier_builder_new(MEMTIER_POLICY_STATIC_THRESHOLD);
         memtier_builder_add_tier(m_tier_builder, MEMKIND_DEFAULT, 1);
-        memtier_builder_set_policy(m_tier_builder,
-                                   MEMTIER_POLICY_STATIC_THRESHOLD);
         m_tier_memory =
             memtier_builder_construct_memtier_memory(m_tier_builder);
     }
@@ -132,10 +130,9 @@ class memtier_multiple_bench_alloc: public counter_bench_alloc
 public:
     memtier_multiple_bench_alloc(memtier_policy_t policy)
     {
-        m_tier_builder = memtier_builder_new();
+        m_tier_builder = memtier_builder_new(policy);
         memtier_builder_add_tier(m_tier_builder, MEMKIND_DEFAULT, 1);
         memtier_builder_add_tier(m_tier_builder, MEMKIND_REGULAR, 1);
-        memtier_builder_set_policy(m_tier_builder, policy);
         m_tier_memory =
             memtier_builder_construct_memtier_memory(m_tier_builder);
     }


### PR DESCRIPTION
- move policy parameter into builder creation method
- remove memtier_builder_set_policy method

Required:
- [X] extract logic in memtier_builder_construct_memtier_memory to interface in builder e.g.
// builder->create_memtier(builder) -> will do in separate PR
- [X] Depends on changes introduced in #624

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/628)
<!-- Reviewable:end -->
