### PR TITLE
Redesign usage of config env vars

### DIFF
--- a/man/memtier.7
+++ b/man/memtier.7
@@ -4,61 +4,65 @@
 .TH "MEMTIER" 7 "2021-03-01" "Intel Corporation" "MEMTIER" \" -*- nroff -*-
 .SH "NAME"
 libmemtier.so \- TODO
+
 .SH "SYNOPSIS"
 .BR LD_PRELOAD=libmemtier.so
 command {arguments ...}
+
 .SH "DESCRIPTION"
 .B TODO
 
 .SH "ENVIRONMENT"
 .TP
-.B MEMKIND_MEM_TIERING_CONFIG
-Sets the memkind tiering functionality. Passed as a comma separated list of
-memory kinds configuration strings ended with a policy. The configuration has to be passed in the following format:
+.B MEMKIND_MEM_TIERS
+Sets the memkind tiering functionality. Passed as a semicolon-separated list of
+tier configurations ended with a policy parameter. Each tier configuration consists of
+a comma-separated list of tier parameters in the following format:
 .IP
-"kind_name:[path_to_pmem:pmem_file_size:]ratio,(...),policy"
-, where:
-.IP
-.BR
-kind_name - the name of a kind used in tiering. Allowed kind names are 'DRAM' and 'FS_DAX'.
-.IP
-.BR
-path_to_pmem - the path to the location where pmem file will be created. The path has to exist. Pass this option
+"param_name:value,(...)"
+, where the param_name is the name of the parameter. For more details about param_name
+see the PARAMETER NAME section below.
+
+.SH "PARAMETER NAME"
+.TP
+KIND (required) - kind of memory used in memory tier. Allowed kind names are 'DRAM' and 'FS_DAX'.
+.TP
+PATH (required for FS_DAX kind) - the path to the location where pmem file will be created. The path has to exist. Pass this option
 only with FS_DAX kind.
-.IP
-.BR
-pmem_file_size - the size of pmem file, it's the maximum size of total allocations to PMEM. Pass this option
-only with FS_DAX kind. The accepted formats are: 1, 1K, 1M, 1G. See
+.TP
+PMEM_SIZE_LIMIT (optional) - if set, it is the limitation size of pmem file and the maximum size of total
+allocations to PMEM. By default no limit is introduced. Pass this option only with FS_DAX kind.
+The accepted formats are: 1, 1K, 1M, 1G. See
 .I memkind(3)
 manual for information about limitations to this value which are the same as for the
 .I max_size
 value in
 .I memkind_create_pmem()
 function.
-.IP
-.BR
-ratio - the part of ratio tied to the given kind. It's represented as an
+.TP
+RATIO (required) - the part of ratio tied to the given kind. It's represented as an
 .I unsigned
 type. Value should be in range from 1 to
 .I UINT_MAX
-.IP
-.BR
-policy - determines the algorithm used to distribute allocations between provided memory kinds. Currently only
-.I POLICY_STATIC_THRESHOLD
+.TP
+POLICY (required) - determines the algorithm used to distribute allocations between
+provided memory kinds. This parameter has to be the last parameter in configuration
+string. Currently only
+.I STATIC_THRESHOLD
 and
-.I POLICY_DYNAMIC_THRESHOLD
+.I DYNAMIC_THRESHOLD
 policies are valid. In
-.I POLICY_STATIC_THRESHOLD
+.I STATIC_THRESHOLD
 all allocations are made in such a way that the ratio between memory kinds is static. In
-.I POLICY_DYNAMIC_THRESHOLD
+.I DYNAMIC_THRESHOLD
 the ratio between adjacent memory tiers is kept with a help of set of thresholds between kinds. TODO
-.IP
+.PP
 See
 .I EXAMPLES
 section for an example of usage of
-.I MEMKIND_MEM_TIERING_CONFIG
+.I MEMKIND_MEM_TIERS
 environment variable.
-.IP
+.br
 NOTE: The application will fail when provided environment variable string is not in a correct format.
 
 .SH "CTL API"
@@ -82,10 +86,10 @@ both libmemtier.so and libmemkind.so are included in
 .B LD_PRELOAD=libmemtier.so
 /bin/ls -l
 .PP
-Example usage of MEMKIND_MEM_TIERING_CONFIG environment variable where 20% of allocations will go to PMEM
+Example usage of MEMKIND_MEM_TIERS environment variable where 20% of allocations will go to PMEM
 and 80% of allocations will go to DRAM:
 .IP
-.B MEMKIND_MEM_TIERING_CONFIG="FS_DAX:/tmp/:10G:1,DRAM:4,POLICY_STATIC_THRESHOLD"
+.B MEMKIND_MEM_TIERS="KIND:FS_DAX,PATH:/tmp/,PMEM_SIZE_LIMIT:10G,RATIO:1;KIND:DRAM,RATIO:4;POLICY:STATIC_THRESHOLD"
 
 .SH "COPYRIGHT"
 Copyright (C) 2021 Intel Corporation. All rights reserved.

--- a/tiering/ctl.c
+++ b/tiering/ctl.c
@@ -13,7 +13,8 @@
 #include <string.h>
 
 #define CTL_VALUE_SEPARATOR        ":"
-#define CTL_STRING_QUERY_SEPARATOR ","
+#define CTL_PARAM_SEPARATOR        ","
+#define CTL_STRING_QUERY_SEPARATOR ";"
 
 #define MAX_KIND 255
 
@@ -150,9 +151,9 @@ parse_failure:
  */
 static int ctl_parse_policy(char *qbuf, memtier_policy_t *policy)
 {
-    if (strcmp(qbuf, "POLICY_STATIC_THRESHOLD") == 0) {
+    if (strcmp(qbuf, "STATIC_THRESHOLD") == 0) {
         *policy = MEMTIER_POLICY_STATIC_THRESHOLD;
-    } else if (strcmp(qbuf, "POLICY_DYNAMIC_THRESHOLD") == 0) {
+    } else if (strcmp(qbuf, "DYNAMIC_THRESHOLD") == 0) {
         *policy = MEMTIER_POLICY_DYNAMIC_THRESHOLD;
     } else {
         log_err("Unknown policy: %s", qbuf);
@@ -186,41 +187,79 @@ static int ctl_parse_ratio(char **sptr, unsigned *dest)
 static int ctl_parse_query(char *qbuf, memkind_t *kind, unsigned *ratio)
 {
     char *sptr = NULL;
-    char *pmem_path = NULL;
-    size_t pmem_size = 1;
+    char *ratio_str = NULL;
     int ret = -1;
 
-    char *kind_name = strtok_r(qbuf, CTL_VALUE_SEPARATOR, &sptr);
-    if (kind_name == NULL) {
-        log_err("Kind name string not found in: %s", qbuf);
+    int is_fsdax = 0;
+    char *fsdax_path = NULL;
+    char *fsdax_size_str = NULL;
+
+    char *param_str = strtok_r(qbuf, CTL_VALUE_SEPARATOR, &sptr);
+    while (param_str != NULL) {
+        if (!strcmp(param_str, "KIND")) {
+            char *kind_name = strtok_r(NULL, CTL_PARAM_SEPARATOR, &sptr);
+            if (!strcmp(kind_name, "DRAM")) {
+                *kind = MEMKIND_DEFAULT;
+            } else if (!strcmp(kind_name, "FS_DAX")) {
+                // for FS_DAX we have to collect all parameteres before
+                // initialization
+                is_fsdax = 1;
+            } else {
+                log_err("Unsupported kind: %s", kind_name);
+                return -1;
+            }
+        } else if (!strcmp(param_str, "PATH")) {
+            fsdax_path = strtok_r(NULL, CTL_PARAM_SEPARATOR, &sptr);
+        } else if (!strcmp(param_str, "PMEM_SIZE_LIMIT")) {
+            fsdax_size_str = strtok_r(NULL, CTL_PARAM_SEPARATOR, &sptr);
+        } else if (!strcmp(param_str, "RATIO")) {
+            ratio_str = strtok_r(NULL, CTL_PARAM_SEPARATOR, &sptr);
+            ret = ctl_parse_ratio(&ratio_str, ratio);
+            if (ret != 0) {
+                return -1;
+            }
+        }
+
+        param_str = strtok_r(NULL, CTL_VALUE_SEPARATOR, &sptr);
+    }
+
+    if (!kind) {
+        log_err("KIND param not found");
+        return -1;
+    } else if (!ratio_str) {
+        log_err("RATIO param not found");
         return -1;
     }
 
-    if (!strcmp(kind_name, "DRAM")) {
-        *kind = MEMKIND_DEFAULT;
-    } else if (!strcmp(kind_name, "FS_DAX")) {
-        pmem_path = strtok_r(NULL, CTL_VALUE_SEPARATOR, &sptr);
-        if (pmem_path == NULL) {
+    if (is_fsdax) {
+        if (!fsdax_path) {
+            log_err("PATH param (required for FS_DAX) not found");
             return -1;
         }
 
-        ret = ctl_parse_pmem_size(&sptr, &pmem_size);
-        if (ret != 0) {
-            return -1;
+        size_t fsdax_max_size = 0;
+        if (fsdax_size_str) {
+            ret = ctl_parse_pmem_size(&fsdax_size_str, &fsdax_max_size);
+            if (ret != 0) {
+                return -1;
+            }
         }
 
-        ret = memkind_create_pmem(pmem_path, pmem_size, kind);
+        ret = memkind_create_pmem(fsdax_path, fsdax_max_size, kind);
         if (ret || ctl_add_pmem_kind_to_fs_dax_reg(*kind)) {
             return -1;
         }
     } else {
-        log_err("Unsupported kind: %s", kind_name);
-        return -1;
-    }
+        if (fsdax_path) {
+            log_err("PATH param can be defined only for FS_DAX kind");
+            return -1;
+        }
 
-    ret = ctl_parse_ratio(&sptr, ratio);
-    if (ret != 0) {
-        return -1;
+        if (fsdax_size_str) {
+            log_err("PMEM_SIZE_LIMIT param can be defined only "
+                    "for FS_DAX kind");
+            return -1;
+        }
     }
 
     /* the value itself mustn't include CTL_VALUE_SEPARATOR */
@@ -285,9 +324,15 @@ struct memtier_memory *ctl_create_tier_memory_from_env(char *env_var_string)
         }
     }
 
-    ret = ctl_parse_policy(qbuf, &policy);
-    if (ret != 0) {
-        log_err("Failed to parse policy: %s", qbuf);
+    qbuf = strtok_r(qbuf, CTL_VALUE_SEPARATOR, &sptr);
+    if (!strcmp(qbuf, "POLICY")) {
+        ret = ctl_parse_policy(sptr, &policy);
+        if (ret != 0) {
+            log_err("Failed to parse policy: %s", qbuf);
+            goto cleanup_after_failure;
+        }
+    } else {
+        log_err("Missing POLICY parameter in the query: %s", qbuf);
         goto cleanup_after_failure;
     }
 

--- a/tiering/memtier.c
+++ b/tiering/memtier.c
@@ -109,15 +109,15 @@ static MEMTIER_INIT void memtier_init(void)
     pthread_once(&init_once, log_init_once);
     log_info("Memkind memtier lib loaded!");
 
-    char *env_var = utils_get_env("MEMKIND_MEM_TIERING_CONFIG");
+    char *env_var = utils_get_env("MEMKIND_MEM_TIERS");
     if (env_var) {
         current_memory = ctl_create_tier_memory_from_env(env_var);
         if (current_memory) {
             return;
         }
-        log_err("Error with parsing MEMKIND_MEM_TIERING_CONFIG");
+        log_err("Error with parsing MEMKIND_MEM_TIERS");
     } else {
-        log_err("Missing MEMKIND_MEM_TIERING_CONFIG env var");
+        log_err("Missing MEMKIND_MEM_TIERS env var");
     }
     abort();
 }


### PR DESCRIPTION
- rename env var to MEMKIND_MEM_TIERS
- all configuration parameters are passed in form PARAM_NAME:VALUE
- parameters are separated by ','
- added new env tests

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/629)
<!-- Reviewable:end -->
