### PR TITLE
Additional memory management variants for memtier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -484,7 +484,7 @@ noinst_PROGRAMS =
 noinst_LTLIBRARIES =
 TESTS =
 
-req_flags = -fvisibility=hidden -Wall -Werror -D_GNU_SOURCE -DJE_PREFIX=@memkind_prefix@
+req_flags = -fvisibility=hidden -Wall -Werror -D_GNU_SOURCE -DJE_PREFIX=@memkind_prefix@ -DMEMTIER_ALLOC_PREFIX=@memtier_prefix@
 
 AM_CFLAGS = $(req_flags)
 AM_CXXFLAGS = $(req_flags)

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,19 @@ fi
 
 AC_SUBST(memkind_prefix)
 
+#============================memtier_prefix===========================================
+memtier_prefix=je_;
+AC_ARG_VAR(MEMTIER_PREFIX,
+  [Prefix used for intercept additional malloc API with libmemtier, default value je_]
+)
+if test "$MEMTIER_PREFIX" != "" ; then
+  memtier_prefix=$MEMTIER_PREFIX;
+fi
+
+AC_SUBST(memtier_prefix)
+if test "$memtier_prefix" == "$memkind_prefix" ; then
+  AC_MSG_ERROR([MEMTIER_PREFIX and MEMKIND_PREFIX cannot be the same])
+fi
 #============================min_log_alignment=====================================
 min_lg_align_opt="";
 AC_ARG_VAR(MIN_LG_ALIGN,

--- a/man/memtier.7
+++ b/man/memtier.7
@@ -133,10 +133,13 @@ and 80% of allocations will go to DAX KMEM nodes:
 .IP
 .B MEMKIND_MEM_TIERS="KIND:DRAM,RATIO:1;KIND:KMEM_DAX,RATIO:4,POLICY:STATIC_THRESHOLD"
 .B TODO Example with dynamic threshold
-
+.SH "NOTES"
+.B libmemtier
+works for applications which does not statically link a
+.B malloc
+implementation.
 .SH "COPYRIGHT"
 Copyright (C) 2021 Intel Corporation. All rights reserved.
-
 .SH "SEE ALSO"
 .BR memkind(3),
 .BR malloc (3)

--- a/tiering/memtier.c
+++ b/tiering/memtier.c
@@ -17,6 +17,17 @@
 #define MEMTIER_LIKELY(x)   __builtin_expect(!!(x), 1)
 #define MEMTIER_UNLIKELY(x) __builtin_expect(!!(x), 0)
 
+#define MT_SYMBOL2(a, b) a##b
+#define MT_SYMBOL1(a, b) MT_SYMBOL2(a, b)
+#define MT_SYMBOL(b)     MT_SYMBOL1(MEMTIER_ALLOC_PREFIX, b)
+
+#define mt_malloc             MT_SYMBOL(malloc)
+#define mt_calloc             MT_SYMBOL(calloc)
+#define mt_realloc            MT_SYMBOL(realloc)
+#define mt_free               MT_SYMBOL(free)
+#define mt_posix_memalign     MT_SYMBOL(posix_memalign)
+#define mt_malloc_usable_size MT_SYMBOL(malloc_usable_size)
+
 static int destructed;
 
 static struct memtier_memory *current_memory;
@@ -130,4 +141,35 @@ static MEMTIER_FINI void memtier_fini(void)
     current_memory = NULL;
 
     destructed = 1;
+}
+
+MEMTIER_EXPORT void *mt_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+MEMTIER_EXPORT void *mt_calloc(size_t num, size_t size)
+{
+    return calloc(num, size);
+}
+
+MEMTIER_EXPORT void *mt_realloc(void *ptr, size_t size)
+{
+    return realloc(ptr, size);
+}
+
+MEMTIER_EXPORT void mt_free(void *ptr)
+{
+    free(ptr);
+}
+
+MEMTIER_EXPORT int mt_posix_memalign(void **memptr, size_t alignment,
+                                     size_t size)
+{
+    return posix_memalign(memptr, alignment, size);
+}
+
+MEMTIER_EXPORT size_t mt_malloc_usable_size(void *ptr)
+{
+    return malloc_usable_size(ptr);
 }


### PR DESCRIPTION
- this allows using memtier LD_PRELOAD mechanism with an application#
  where instead of "glibc malloc" another malloc is used, e.g. je_malloc
- prefix is adjustable by using ./configure option MEMTIER_PREFIX
- MEMTIER_PREFIX must be different than MEMKIND_PREFIX

Note:
this mechanism would work only if another allocator is linked dynamically


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/638)
<!-- Reviewable:end -->
