### PR TITLE
Add test that checks average per-tier alloc size

### DIFF
--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -174,6 +174,53 @@ protected:
     }
 };
 
+class MemkindMemtierThresholdSizesTest: public ::testing::Test
+{
+protected:
+    struct memtier_memory *m_tier_memory;
+
+    const int MEMKIND_DEFAULT_ratio = 1;
+    const int MEMKIND_REGULAR_ratio = 1;
+
+    const float m_tier_regular_normalized_ratio =
+        (float)MEMKIND_REGULAR_ratio / MEMKIND_DEFAULT_ratio;
+
+    size_t allocation_sum()
+    {
+        return memtier_kind_allocated_size(MEMKIND_DEFAULT) +
+            memtier_kind_allocated_size(MEMKIND_REGULAR);
+    }
+
+    void SetUp()
+    {
+        struct memtier_builder *builder =
+            memtier_builder_new(MEMTIER_POLICY_DYNAMIC_THRESHOLD);
+        ASSERT_NE(nullptr, builder);
+        int res = memtier_builder_add_tier(builder, MEMKIND_DEFAULT,
+                                           MEMKIND_DEFAULT_ratio);
+        ASSERT_EQ(0, res);
+        res = memtier_builder_add_tier(builder, MEMKIND_REGULAR,
+                                       MEMKIND_REGULAR_ratio);
+        ASSERT_EQ(0, res);
+        size_t min = 8;
+        res = memtier_ctl_set(
+            builder, "policy.dynamic_threshold.thresholds[0].min", &min);
+        ASSERT_EQ(0, res);
+        size_t val = 64;
+        res = memtier_ctl_set(
+            builder, "policy.dynamic_threshold.thresholds[0].val", &val);
+        ASSERT_EQ(0, res);
+        m_tier_memory = memtier_builder_construct_memtier_memory(builder);
+        ASSERT_NE(nullptr, m_tier_memory);
+        memtier_builder_delete(builder);
+    }
+
+    void TearDown()
+    {
+        memtier_delete_memtier_memory(m_tier_memory);
+    }
+};
+
 TEST_F(MemkindMemtierKindTest, test_tier_size_after_destroy)
 {
     const size_t size = 512;
@@ -1308,6 +1355,83 @@ TEST_F(MemkindMemtierThresholdTest, test_various_alloc_size)
     float def_reg_dist = abs(m_tier_regular_normalized_ratio - reg_def_ratio) /
         (m_tier_regular_normalized_ratio);
     ASSERT_LE(def_reg_dist, max_ratio_distance);
+
+    for (auto const &ptr : allocs) {
+        memtier_free(ptr);
+    }
+}
+
+TEST_F(MemkindMemtierThresholdSizesTest, test_final_alloc_sizes)
+{
+    size_t i;
+
+    const int alloc_sizes_num = 9;
+    const size_t alloc_sizes[alloc_sizes_num] = {16, 16, 16, 16, 16,
+                                                 16, 16, 16, 128};
+    const int alloc_num = 5000;
+    size_t sizes[alloc_num];
+    std::vector<void *> allocs;
+
+    // initialize sizes array
+    srand(1);
+    for (i = 0; i < alloc_num; ++i) {
+        unsigned size_id = rand() % alloc_sizes_num;
+        sizes[i] = alloc_sizes[size_id];
+    }
+
+    size_t default_alloc_size = 0;
+    size_t regular_alloc_size = 0;
+    std::vector<size_t> default_sizes;
+    std::vector<size_t> regular_sizes;
+
+    // do allocations
+    for (i = 0; i < alloc_num; ++i) {
+        void *ptr = memtier_malloc(m_tier_memory, sizes[i]);
+        ASSERT_NE(nullptr, ptr);
+        allocs.push_back(ptr);
+
+        size_t new_default_alloc_size =
+            memtier_kind_allocated_size(MEMKIND_DEFAULT);
+        size_t new_regular_alloc_size =
+            memtier_kind_allocated_size(MEMKIND_REGULAR);
+
+        if (new_default_alloc_size > default_alloc_size) {
+            default_sizes.push_back(sizes[i]);
+            default_alloc_size = new_default_alloc_size;
+        } else {
+            regular_sizes.push_back(sizes[i]);
+            regular_alloc_size = new_regular_alloc_size;
+        }
+    }
+
+    // check if actual ratios between tiers are close to desired
+    const float max_ratio_distance = 0.10; // 10%
+
+    float reg_def_ratio = (float)regular_alloc_size / default_alloc_size;
+
+    float def_reg_dist = abs(m_tier_regular_normalized_ratio - reg_def_ratio) /
+        (m_tier_regular_normalized_ratio);
+    ASSERT_LE(def_reg_dist, max_ratio_distance);
+
+    // check if average allocation size in MEMKIND_DEFAULT is close to 16 and
+    // average allocation size in MEMKIND_REGULAR is close to 128
+    const float max_size_distance = 0.25; // 25%
+
+    float avg_default_size = 0;
+    for (size_t const &s : default_sizes) {
+        avg_default_size += (float)s / default_sizes.size();
+    }
+
+    float size_dist = abs(16 - avg_default_size) / 16;
+    ASSERT_LE(size_dist, max_size_distance);
+
+    float avg_regular_size = 0;
+    for (size_t const &s : regular_sizes) {
+        avg_regular_size += (float)s / regular_sizes.size();
+    }
+
+    size_dist = abs(128 - avg_regular_size) / 128;
+    ASSERT_LE(size_dist, max_size_distance);
 
     for (auto const &ptr : allocs) {
         memtier_free(ptr);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/645)
<!-- Reviewable:end -->
