### PR TITLE
Fix ThreadHash test failure

### DIFF
--- a/test/get_arena_test.cpp
+++ b/test/get_arena_test.cpp
@@ -37,7 +37,7 @@ TEST_F(GetArenaTest, test_TC_MEMKIND_ThreadHash)
     size_t size = 0;
     int i;
     unsigned max_collisions, collisions;
-    const unsigned collisions_limit = 5;
+    const unsigned collisions_limit = 7;
 
     // Initialize kind
     memkind_malloc(MEMKIND_HBW, 0);


### PR DESCRIPTION
16 out of 1000 test runs of the test_TC_MEMKIND_ThreadHash test failed.
Maximum number of collisions in failing runs was 7.
Most probably commit 1e6ede0 introduced the increased number of
collisions.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/651)
<!-- Reviewable:end -->
