### PR TITLE
Revert "Bump compiler version in GHA"

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        compiler_version: [11]
+        compiler_version: [10]
         env:
           - { cc: gcc, cxx: g++}
           - { cc: clang, cxx: clang++}


### PR DESCRIPTION
This reverts commit c0bc8a925e93ab7cee1d7b0ed2eb80c007ac9015.
Hwloc have issues with gcc-11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/662)
<!-- Reviewable:end -->
