### PR TITLE
Improve DYNAMIC_THRESHOLD policy

### DIFF
--- a/test/memkind_memtier_test.cpp
+++ b/test/memkind_memtier_test.cpp
@@ -1267,7 +1267,7 @@ TEST_F(MemkindMemtierThresholdTest, test_const_alloc_size)
     // Start checking distance between actual and desired ratio
     // after "ratio_check_skip" allocations
     const unsigned ratio_check_skip = 1000;
-    const float max_ratio_distance = 0.41; // 41%
+    const float max_ratio_distance = 0.20; // 20%
 
     for (unsigned i = 0; i < num_allocs; ++i) {
         void *ptr = memtier_malloc(m_tier_memory, alloc_size);
@@ -1302,7 +1302,7 @@ TEST_F(MemkindMemtierThresholdTest, test_various_alloc_size)
     const int alloc_sizes_num = 10;
     const size_t alloc_sizes[alloc_sizes_num] = {4,   8,   16,  32,   64,
                                                  128, 256, 512, 1024, 1024 * 2};
-    const int alloc_num = 10000;
+    const int alloc_num = 20000;
     size_t sizes[alloc_num];
     std::vector<void *> allocs;
 


### PR DESCRIPTION
- don't change threshold if current ratio is better than previously calculated
- adjust algorithm properties: do checks less frequenlty and decrease
  change trigger and degree to make threshold value changing more smoothly

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/667)
<!-- Reviewable:end -->
