### PR TITLE
Optimize memkind_malloc_usable_size

### DIFF
--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -38,7 +38,6 @@ int memkind_arena_finalize(struct memkind *kind);
 void memkind_arena_init(struct memkind *kind);
 void memkind_arena_free(struct memkind *kind, void *ptr);
 void memkind_arena_free_with_kind_detect(void *ptr);
-size_t memkind_arena_malloc_usable_size(void *ptr);
 int memkind_arena_update_memory_usage_policy(struct memkind *kind,
                                              memkind_mem_usage_policy policy);
 int memkind_arena_set_max_bg_threads(size_t threads_limit);

--- a/man/memkind_arena.3
+++ b/man/memkind_arena.3
@@ -41,8 +41,6 @@ This is EXPERIMENTAL API. The functionality and the header file itself can be ch
 .br
 .BI "void memkind_arena_free_with_kind_detect(void " "*ptr" );
 .br
-.BI "size_t memkind_arena_malloc_usable_size(void " "*ptr" );
-.br
 .BI "int memkind_arena_update_memory_usage_policy(struct memkind " "*kind" ", memkind_mem_usage_policy " "policy" );
 .br
 .BI "int memkind_arena_set_max_bg_threads(size_t " "threads_limit" );
@@ -184,9 +182,6 @@ returns pointer to memory kind structure associated with given allocated memory 
 .PP
 .BR get_kind_by_arena ()
 returns pointer to memory kind structure associated with given arena.
-.PP
-.BR memkind_arena_malloc_usable_size ()
-is an implementation of the memkind "usable_size" operation for memory kinds that use jemalloc.
 .PP
 .BR memkind_arena_finalize ()
 is an implementation of the memkind "finalize" operation for memory kinds that

--- a/src/heap_manager.c
+++ b/src/heap_manager.c
@@ -29,7 +29,7 @@ struct heap_manager_ops {
 
 static struct heap_manager_ops arena_heap_manager_g = {
     .init = memkind_arena_init,
-    .heap_manager_malloc_usable_size = memkind_arena_malloc_usable_size,
+    .heap_manager_malloc_usable_size = jemk_malloc_usable_size,
     .heap_manager_free = memkind_arena_free_with_kind_detect,
     .heap_manager_realloc = memkind_arena_realloc_with_kind_detect,
     .heap_manager_detect_kind = memkind_arena_detect_kind,

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -55,7 +55,7 @@
 #define m_detect_kind(ptr)                      memkind_arena_detect_kind(ptr)
 #define m_free(ptr)                             memkind_arena_free_with_kind_detect(ptr)
 #define m_realloc(ptr, size)                    memkind_arena_realloc_with_kind_detect(ptr, size)
-#define m_usable_size(ptr)                      memkind_default_malloc_usable_size(NULL, ptr)
+#define m_usable_size(ptr)                      jemk_malloc_usable_size(ptr)
 #define m_defrag_reallocate(ptr)                memkind_arena_defrag_reallocate_with_kind_detect(ptr)
 #define m_get_global_stat(stat, value)          memkind_arena_get_global_stat(stat, value)
 #define m_update_cached_stats                   memkind_arena_update_cached_stats

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -501,11 +501,6 @@ MEMKIND_EXPORT void memkind_arena_free_with_kind_detect(void *ptr)
     memkind_arena_free(kind, ptr);
 }
 
-MEMKIND_EXPORT size_t memkind_arena_malloc_usable_size(void *ptr)
-{
-    return memkind_default_malloc_usable_size(NULL, ptr);
-}
-
 MEMKIND_EXPORT void *memkind_arena_realloc(struct memkind *kind, void *ptr,
                                            size_t size)
 {


### PR DESCRIPTION
- call jemk_malloc_usable_size directly if heap manager is disabled
- remove memkind_arena_malloc_usable_size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/674)
<!-- Reviewable:end -->
