### PR TITLE
Optimize MEMKIND_DEFAULT paths

### DIFF
--- a/src/memkind.c
+++ b/src/memkind.c
@@ -745,15 +745,13 @@ MEMKIND_EXPORT size_t memkind_malloc_usable_size(struct memkind *kind,
 
 MEMKIND_EXPORT void *memkind_malloc(struct memkind *kind, size_t size)
 {
-    void *result;
-
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_malloc_pre) {
         memkind_malloc_pre(&kind, &size);
     }
 #endif
 
-    result = kind->ops->malloc(kind, size);
+    void *result = kind->ops->malloc(kind, size);
 
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_malloc_post) {
@@ -767,15 +765,13 @@ MEMKIND_EXPORT void *memkind_malloc(struct memkind *kind, size_t size)
 MEMKIND_EXPORT void *memkind_calloc(struct memkind *kind, size_t num,
                                     size_t size)
 {
-    void *result;
-
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_calloc_pre) {
         memkind_calloc_pre(&kind, &num, &size);
     }
 #endif
 
-    result = kind->ops->calloc(kind, num, size);
+    void *result = kind->ops->calloc(kind, num, size);
 
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_calloc_post) {
@@ -789,15 +785,13 @@ MEMKIND_EXPORT void *memkind_calloc(struct memkind *kind, size_t num,
 MEMKIND_EXPORT int memkind_posix_memalign(struct memkind *kind, void **memptr,
                                           size_t alignment, size_t size)
 {
-    int err;
-
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_posix_memalign_pre) {
         memkind_posix_memalign_pre(&kind, memptr, &alignment, &size);
     }
 #endif
 
-    err = kind->ops->posix_memalign(kind, memptr, alignment, size);
+    int err = kind->ops->posix_memalign(kind, memptr, alignment, size);
 
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_posix_memalign_post) {

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -747,8 +747,6 @@ MEMKIND_EXPORT void *memkind_malloc(struct memkind *kind, size_t size)
 {
     void *result;
 
-    pthread_once(&kind->init_once, kind->ops->init_once);
-
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_malloc_pre) {
         memkind_malloc_pre(&kind, &size);
@@ -771,8 +769,6 @@ MEMKIND_EXPORT void *memkind_calloc(struct memkind *kind, size_t num,
 {
     void *result;
 
-    pthread_once(&kind->init_once, kind->ops->init_once);
-
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_calloc_pre) {
         memkind_calloc_pre(&kind, &num, &size);
@@ -794,8 +790,6 @@ MEMKIND_EXPORT int memkind_posix_memalign(struct memkind *kind, void **memptr,
                                           size_t alignment, size_t size)
 {
     int err;
-
-    pthread_once(&kind->init_once, kind->ops->init_once);
 
 #ifdef MEMKIND_DECORATION_ENABLED
     if (memkind_posix_memalign_pre) {
@@ -828,7 +822,6 @@ MEMKIND_EXPORT void *memkind_realloc(struct memkind *kind, void *ptr,
     if (!kind) {
         result = m_realloc(ptr, size);
     } else {
-        pthread_once(&kind->init_once, kind->ops->init_once);
         result = kind->ops->realloc(kind, ptr, size);
     }
 
@@ -851,7 +844,6 @@ MEMKIND_EXPORT void memkind_free(struct memkind *kind, void *ptr)
     if (!kind) {
         m_free(ptr);
     } else {
-        pthread_once(&kind->init_once, kind->ops->init_once);
         kind->ops->free(kind, ptr);
     }
 

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -511,24 +511,20 @@ MEMKIND_EXPORT void *memkind_arena_realloc(struct memkind *kind, void *ptr,
 
     if (size == 0 && ptr != NULL) {
         jemk_dallocx(ptr, get_tcache_flag(kind->partition, 0));
-        ptr = NULL;
-    } else {
-        int err = kind->ops->get_arena(kind, &arena, size);
-        if (MEMKIND_LIKELY(!err)) {
-            if (ptr == NULL) {
-                ptr = jemk_mallocx_check(
-                    size,
-                    MALLOCX_ARENA(arena) |
-                        get_tcache_flag(kind->partition, size));
-            } else {
-                ptr = jemk_rallocx_check(
-                    ptr, size,
-                    MALLOCX_ARENA(arena) |
-                        get_tcache_flag(kind->partition, size));
-            }
-        }
+        return NULL;
     }
-    return ptr;
+    int err = kind->ops->get_arena(kind, &arena, size);
+    if (MEMKIND_LIKELY(!err)) {
+        if (ptr == NULL) {
+            return jemk_mallocx_check(
+                size,
+                MALLOCX_ARENA(arena) | get_tcache_flag(kind->partition, size));
+        }
+        return jemk_rallocx_check(ptr, size,
+                                  MALLOCX_ARENA(arena) |
+                                      get_tcache_flag(kind->partition, size));
+    }
+    return NULL;
 }
 
 int memkind_arena_update_cached_stats(void)

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -862,7 +862,7 @@ void *memkind_arena_defrag_reallocate(struct memkind *kind, void *ptr)
     }
 
     if (!jemk_check_reallocatex(ptr)) {
-        size_t size = memkind_malloc_usable_size(kind, ptr);
+        size_t size = jemk_malloc_usable_size(ptr);
         void *ptr_new = memkind_arena_malloc_no_tcache(kind, size);
         if (MEMKIND_UNLIKELY(!ptr_new))
             return NULL;

--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -547,9 +547,8 @@ MEMKIND_EXPORT void *memkind_arena_realloc_with_kind_detect(void *ptr,
     struct memkind *kind = memkind_arena_detect_kind(ptr);
     if (kind == MEMKIND_DEFAULT) {
         return memkind_default_realloc(kind, ptr, size);
-    } else {
-        return memkind_arena_realloc(kind, ptr, size);
     }
+    return memkind_arena_realloc(kind, ptr, size);
 }
 
 MEMKIND_EXPORT int


### PR DESCRIPTION
- avoid pthread_once operation for MEMKIND_DEFAULT
- call jemk_dallocx in memkind_arena_realloc function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/675)
<!-- Reviewable:end -->
