### PR TITLE
Move logging mechanism to memkind_memtier layer

### DIFF
--- a/man/memkind_memtier.3
+++ b/man/memkind_memtier.3
@@ -52,6 +52,20 @@ functionality is considered as stable API (STANDARD API).
 .br
 .BI "size_t memtier_kind_allocated_size(memkind_t " "kind" );
 .sp
+.B "DECORATORS:"
+.br
+.BI "void memtier_kind_malloc_post(memkind_t " "kind" ", size_t " "size" ", void " "**result" );
+.br
+.BI "void memtier_kind_calloc_post(memkind_t " "kind" ", size_t " "nmemb" ", size_t " "size" ", void " "**result" );
+.br
+.BI "void memtier_kind_posix_memalign_post(memkind_t " "kind" ", void " "**memptr" ", size_t " "alignment" ", size_t " "size" ", int " "*err" );
+.br
+.BI "void memtier_kind_realloc_post(memkind_t " "*kind" ", void " "*ptr" ", size_t " "size" ", void " "**result" );
+.br
+.BI "void memtier_kind_free_pre(void " "**ptr" );
+.br
+.BI "void memtier_kind_usable_size_post(void " "**ptr" ", size_t " "size" );
+.sp
 .B "MEMTIER PROPERTY MANAGEMENT:
 .br
 .BI "int memtier_ctl_set(struct memtier_builder " "*builder" ", const char " "*name" ", const void " "*val" );
@@ -67,6 +81,14 @@ policy.dynamic_threshold.thresholds[ID].max (size_t)
 policy.dynamic_threshold.check_cnt (unsigned)
 policy.dynamic_threshold.trigger (float)
 policy.dynamic_threshold.degree (float)
+.sp
+.SH "DECORATORS"
+.br
+See section
+.BR "DECORATORS"
+of
+.BR memkind (3)
+for more details about decorators.
 .SH "DESCRIPTION"
 .SH "COPYRIGHT"
 Copyright (C) 2021 Intel Corporation. All rights reserved.

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -135,6 +135,20 @@ struct memtier_memory {
 static MEMKIND_ATOMIC long long t_alloc_size[MEMKIND_MAX_KIND][THREAD_BUCKETS];
 static MEMKIND_ATOMIC size_t g_alloc_size[MEMKIND_MAX_KIND];
 
+/* Declare weak symbols for allocator decorators */
+extern void memtier_kind_malloc_post(struct memkind *, size_t, void **)
+    __attribute__((weak));
+extern void memtier_kind_calloc_post(struct memkind *, size_t, size_t, void **)
+    __attribute__((weak));
+extern void memtier_kind_posix_memalign_post(struct memkind *, void **, size_t,
+                                             size_t, int *)
+    __attribute__((weak));
+extern void memtier_kind_realloc_post(struct memkind *, void *, size_t, void **)
+    __attribute__((weak));
+extern void memtier_kind_free_pre(void **) __attribute__((weak));
+extern void memtier_kind_usable_size_post(void **, size_t)
+    __attribute__((weak));
+
 void memtier_reset_size(unsigned kind_id)
 {
     unsigned bucket_id;
@@ -688,6 +702,10 @@ MEMKIND_EXPORT void *memtier_kind_malloc(memkind_t kind, size_t size)
 {
     void *ptr = memkind_malloc(kind, size);
     increment_alloc_size(kind->partition, jemk_malloc_usable_size(ptr));
+#ifdef MEMKIND_DECORATION_ENABLED
+    if (memtier_kind_malloc_post)
+        memtier_kind_malloc_post(kind, size, &ptr);
+#endif
     return ptr;
 }
 
@@ -705,6 +723,11 @@ MEMKIND_EXPORT void *memtier_kind_calloc(memkind_t kind, size_t num,
 {
     void *ptr = memkind_calloc(kind, num, size);
     increment_alloc_size(kind->partition, jemk_malloc_usable_size(ptr));
+
+#ifdef MEMKIND_DECORATION_ENABLED
+    if (memtier_kind_calloc_post)
+        memtier_kind_calloc_post(kind, num, size, &ptr);
+#endif
     return ptr;
 }
 
@@ -730,6 +753,10 @@ MEMKIND_EXPORT void *memtier_kind_realloc(memkind_t kind, void *ptr,
                                           size_t size)
 {
     if (size == 0 && ptr != NULL) {
+#ifdef MEMKIND_DECORATION_ENABLED
+        if (memtier_kind_free_pre)
+            memtier_kind_free_pre(&ptr);
+#endif
         decrement_alloc_size(kind->partition, jemk_malloc_usable_size(ptr));
         memkind_free(kind, ptr);
         return NULL;
@@ -740,6 +767,10 @@ MEMKIND_EXPORT void *memtier_kind_realloc(memkind_t kind, void *ptr,
 
     void *n_ptr = memkind_realloc(kind, ptr, size);
     increment_alloc_size(kind->partition, jemk_malloc_usable_size(n_ptr));
+#ifdef MEMKIND_DECORATION_ENABLED
+    if (memtier_kind_realloc_post)
+        memtier_kind_realloc_post(kind, ptr, size, &n_ptr);
+#endif
     return n_ptr;
 }
 
@@ -759,21 +790,35 @@ MEMKIND_EXPORT int memtier_kind_posix_memalign(memkind_t kind, void **memptr,
 {
     int res = memkind_posix_memalign(kind, memptr, alignment, size);
     increment_alloc_size(kind->partition, jemk_malloc_usable_size(*memptr));
+#ifdef MEMKIND_DECORATION_ENABLED
+    if (memtier_kind_posix_memalign_post)
+        memtier_kind_posix_memalign_post(kind, memptr, alignment, size, &res);
+#endif
     return res;
 }
 
 MEMKIND_EXPORT size_t memtier_usable_size(void *ptr)
 {
-    return jemk_malloc_usable_size(ptr);
+    size_t size = jemk_malloc_usable_size(ptr);
+#ifdef MEMKIND_DECORATION_ENABLED
+    if (memtier_kind_usable_size_post)
+        memtier_kind_usable_size_post(&ptr, size);
+#endif
+    return size;
 }
 
 MEMKIND_EXPORT void memtier_kind_free(memkind_t kind, void *ptr)
 {
+#ifdef MEMKIND_DECORATION_ENABLED
+    if (memtier_kind_free_pre)
+        memtier_kind_free_pre(&ptr);
+#endif
     if (!kind) {
         kind = memkind_detect_kind(ptr);
         if (!kind)
             return;
     }
+
     decrement_alloc_size(kind->partition, jemk_malloc_usable_size(ptr));
     memkind_free(kind, ptr);
 }

--- a/src/memkind_memtier.c
+++ b/src/memkind_memtier.c
@@ -734,9 +734,7 @@ MEMKIND_EXPORT void *memtier_kind_realloc(memkind_t kind, void *ptr,
         memkind_free(kind, ptr);
         return NULL;
     } else if (ptr == NULL) {
-        void *n_ptr = memkind_malloc(kind, size);
-        increment_alloc_size(kind->partition, jemk_malloc_usable_size(n_ptr));
-        return n_ptr;
+        return memtier_kind_malloc(kind, size);
     }
     decrement_alloc_size(kind->partition, jemk_malloc_usable_size(ptr));
 

--- a/tiering/memtier.c
+++ b/tiering/memtier.c
@@ -28,77 +28,107 @@
 #define mt_posix_memalign     MT_SYMBOL(posix_memalign)
 #define mt_malloc_usable_size MT_SYMBOL(malloc_usable_size)
 
+#ifdef MEMKIND_DECORATION_ENABLED
+#include <memkind/internal/memkind_private.h>
+MEMTIER_EXPORT void memtier_kind_malloc_post(struct memkind *kind, size_t size,
+                                             void **result)
+{
+    log_debug("kind: %s, malloc:(%zu) = %p", kind->name, size, *result);
+}
+
+MEMTIER_EXPORT void memtier_kind_calloc_post(memkind_t kind, size_t num,
+                                             size_t size, void **result)
+{
+    log_debug("kind: %s, calloc:(%zu, %zu) = %p", kind->name, num, size,
+              *result);
+}
+
+MEMTIER_EXPORT void memtier_kind_realloc_post(struct memkind *kind, void *ptr,
+                                              size_t size, void **result)
+{
+    log_debug("kind: %s, realloc(%p, %zu) = %p", kind->name, ptr, size,
+              *result);
+}
+
+MEMTIER_EXPORT void memtier_kind_posix_memalign_post(memkind_t kind,
+                                                     void **memptr,
+                                                     size_t alignment,
+                                                     size_t size, int *err)
+{
+    log_debug("kind: %s, posix_memalign(%p, %zu, %zu) = %d", kind->name,
+              *memptr, alignment, size, err);
+}
+
+MEMTIER_EXPORT void memtier_kind_free_pre(void **ptr)
+{
+    struct memkind *kind = memkind_detect_kind(*ptr);
+    if (kind)
+        log_debug("kind: %s, free(%p)", kind->name, *ptr);
+    else
+        log_debug("free(%p)", *ptr);
+}
+
+MEMTIER_EXPORT void memtier_kind_usable_size_post(void **ptr, size_t size)
+{
+    struct memkind *kind = memkind_detect_kind(*ptr);
+    if (kind)
+        log_debug("kind: %s, malloc_usable_size(%p) = %zu", kind->name, *ptr,
+                  size);
+    else
+        log_debug("malloc_usable_size(%p) = %zu", *ptr, size);
+}
+#endif
+
 static int destructed;
 
 static struct memtier_memory *current_memory;
 
 MEMTIER_EXPORT void *malloc(size_t size)
 {
-    void *ret = NULL;
-
     if (MEMTIER_LIKELY(current_memory)) {
-        ret = memtier_malloc(current_memory, size);
+        return memtier_malloc(current_memory, size);
     } else if (destructed == 0) {
-        ret = memkind_malloc(MEMKIND_DEFAULT, size);
+        return memkind_malloc(MEMKIND_DEFAULT, size);
     }
-
-    // TODO after implementation of decorators memtier decorators this
-    // logging call will be obsolete
-    log_debug("malloc(%zu) = %p", size, ret);
-    return ret;
+    return NULL;
 }
 
 MEMTIER_EXPORT void *calloc(size_t num, size_t size)
 {
-    void *ret = NULL;
-
     if (MEMTIER_LIKELY(current_memory)) {
-        ret = memtier_calloc(current_memory, num, size);
+        return memtier_calloc(current_memory, num, size);
     } else if (destructed == 0) {
-        ret = memkind_calloc(MEMKIND_DEFAULT, num, size);
+        return memkind_calloc(MEMKIND_DEFAULT, num, size);
     }
-
-    log_debug("calloc(%zu, %zu) = %p", num, size, ret);
-    return ret;
+    return NULL;
 }
 
 MEMTIER_EXPORT void *realloc(void *ptr, size_t size)
 {
-    void *ret = NULL;
-
     if (MEMTIER_LIKELY(current_memory)) {
-        ret = memtier_realloc(current_memory, ptr, size);
+        return memtier_realloc(current_memory, ptr, size);
     } else if (destructed == 0) {
-        ret = memkind_realloc(MEMKIND_DEFAULT, ptr, size);
+        return memkind_realloc(MEMKIND_DEFAULT, ptr, size);
     }
-
-    log_debug("realloc(%p, %zu) = %p", ptr, size, ret);
-    return ret;
+    return NULL;
 }
 
 // clang-format off
 MEMTIER_EXPORT int posix_memalign(void **memptr, size_t alignment, size_t size)
 {
-    int ret = 0;
-
     if (MEMTIER_LIKELY(current_memory)) {
-        ret = memtier_posix_memalign(current_memory, memptr, alignment,
+        return memtier_posix_memalign(current_memory, memptr, alignment,
                                           size);
     } else if (destructed == 0) {
-        ret = memkind_posix_memalign(MEMKIND_DEFAULT, memptr, alignment,
+        return memkind_posix_memalign(MEMKIND_DEFAULT, memptr, alignment,
                                      size);
     }
-
-    log_debug("posix_memalign(%p, %zu, %zu) = %d",
-              memptr, alignment, size, ret);
-    return ret;
+    return 0;
 }
 // clang-format on
 
 MEMTIER_EXPORT void free(void *ptr)
 {
-    log_debug("free(%p)", ptr);
-
     if (MEMTIER_LIKELY(current_memory)) {
         memtier_realloc(current_memory, ptr, 0);
     } else if (destructed == 0) {
@@ -108,8 +138,6 @@ MEMTIER_EXPORT void free(void *ptr)
 
 MEMTIER_EXPORT size_t malloc_usable_size(void *ptr)
 {
-    log_debug("malloc_usable_size(%p)", ptr);
-
     return memtier_usable_size(ptr);
 }
 


### PR DESCRIPTION
- option enabled by --enable-memtier-logging
- this logging is enabled on configure layer - no other variables are required here

Alternative solution for #646 

Example log:

> MEMKIND_ALWAYS: kind: memkind_regular, malloc_usable_size(0x7fdcb2ce2000)
> MEMKIND_ALWAYS: kind: memkind_default, calloc:(10, 1024) = 0x7fdcb333b000
> MEMKIND_ALWAYS: kind: memkind_default, malloc_usable_size(0x7fdcb333b000)
> MEMKIND_ALWAYS: kind: memkind_default, calloc:(10, 4096) = 0x7fdcb3360400


@bratpiorka please share your feedback regarding the logging mechanism used in this PR.

I used a logging mechanism from the memkind layer let me know how you would like to this be done in correlation to memkind_memtier logging mechanism

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/680)
<!-- Reviewable:end -->
