### PR TITLE
fix a couple of warnings

### DIFF
--- a/src/memkind_arena.c
+++ b/src/memkind_arena.c
@@ -417,7 +417,6 @@ MEMKIND_EXPORT int memkind_arena_destroy(struct memkind *kind)
 #endif
     }
 
-    memkind_default_destroy(kind);
     return 0;
 }
 

--- a/tiering/memtier_log.c
+++ b/tiering/memtier_log.c
@@ -71,12 +71,11 @@ void log_info(const char *format, ...)
 
 void log_err(const char *format, ...)
 {
-    if (log_level >= MESSAGE_TYPE_ERROR) {
-        va_list args;
-        va_start(args, format);
-        log_generic(MESSAGE_TYPE_ERROR, format, args);
-        va_end(args);
-    }
+    // logging errors can't be disabled
+    va_list args;
+    va_start(args, format);
+    log_generic(MESSAGE_TYPE_ERROR, format, args);
+    va_end(args);
 }
 
 void log_debug(const char *format, ...)


### PR DESCRIPTION
There's a new static analyzer, at lgtm.com.  Outside of jemalloc code, we have two warnings.

Both are only for unused code rather than actual bugs, but it's still good to fix them, at least for readability.

https://lgtm.com/projects/g/memkind/memkind/?mode=list
