### PR TITLE
Extend STANDARD Memkind API with memkind_get_free_space() function

### DIFF
--- a/include/memkind.h
+++ b/include/memkind.h
@@ -515,6 +515,14 @@ int memkind_create_pmem_with_config(struct memkind_config *cfg,
 int memkind_check_available(memkind_t kind);
 
 ///
+/// \brief Get free space
+/// \note STANDARD API
+/// \param kind specified memory kind
+/// \return Free space in bytes on success, -1 on failure
+///
+long long memkind_get_free_space(memkind_t kind);
+
+///
 /// \brief Update memkind cached statistics
 /// \note STANDARD API
 /// \return Memkind operation status, MEMKIND_SUCCESS on success, other values

--- a/man/memkind.3
+++ b/man/memkind.3
@@ -70,6 +70,8 @@ This header expose STANDARD and EXPERIMENTAL API. API Standards are described be
 .br
 .BI "int memkind_check_available(memkind_t " "kind" );
 .br
+.BI "int memkind_get_available_space(memkind_t " "kind" );
+.br
 .BI "int memkind_check_dax_path(const char " "*pmem_dir" );
 .sp
 .B "STATISTICS:"
@@ -552,6 +554,11 @@ returns zero if the specified
 is available or an error code from the
 .B ERRORS
 section if it is not.
+.PP
+.BR memkind_get_available_space ()
+returns space available on given
+.I kind
+or -1 in case of error.
 .PP
 .BR memkind_check_dax_path ()
 returns zero if file-backed kind memory is in the specified directory path


### PR DESCRIPTION
- this function returns free space in the PMEM file for PMEM kind
  or, for the other kinds, the sum of free space for all NUMA nodes
  where a given kind could allocate

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/700)
<!-- Reviewable:end -->
