### PR TITLE
Allocate PMem kind metadata from main memory

### DIFF
--- a/include/memkind/internal/memkind_arena.h
+++ b/include/memkind/internal/memkind_arena.h
@@ -22,7 +22,8 @@ struct memkind *get_kind_by_arena(unsigned arena_ind);
 struct memkind *memkind_arena_detect_kind(void *ptr);
 int memkind_arena_create(struct memkind *kind, struct memkind_ops *ops,
                          const char *name);
-int memkind_arena_create_map(struct memkind *kind, extent_hooks_t *hooks);
+int memkind_arena_create_map(struct memkind *kind, extent_hooks_t *hooks,
+                             bool metadata_use_hooks);
 int memkind_arena_destroy(struct memkind *kind);
 void *memkind_arena_malloc(struct memkind *kind, size_t size);
 void *memkind_arena_calloc(struct memkind *kind, size_t num, size_t size);

--- a/jemalloc/include/jemalloc/internal/arena_externs.h
+++ b/jemalloc/include/jemalloc/internal/arena_externs.h
@@ -83,7 +83,7 @@ unsigned arena_nthreads_get(arena_t *arena, bool internal);
 void arena_nthreads_inc(arena_t *arena, bool internal);
 void arena_nthreads_dec(arena_t *arena, bool internal);
 size_t arena_extent_sn_next(arena_t *arena);
-arena_t *arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
+arena_t *arena_new(tsdn_t *tsdn, unsigned ind, const arena_config_t *config);
 bool arena_init_huge(void);
 bool arena_is_huge(unsigned arena_ind);
 arena_t *arena_choose_huge(tsd_t *tsd);

--- a/jemalloc/include/jemalloc/internal/arena_types.h
+++ b/jemalloc/include/jemalloc/internal/arena_types.h
@@ -48,4 +48,19 @@ typedef enum {
  */
 #define OVERSIZE_THRESHOLD_DEFAULT (8 << 20)
 
+struct arena_config_s {
+	/* extent hooks to be used for the arena */
+	struct extent_hooks_s *extent_hooks;
+
+	/*
+	 * Use provided hooks for metadata (base) allocations when true.
+	 * Ignored if extent_hooks is NULL.
+	 */
+	bool metadata_use_hooks;
+};
+
+typedef struct arena_config_s arena_config_t;
+
+extern const arena_config_t arena_config_default;
+
 #endif /* JEMALLOC_INTERNAL_ARENA_TYPES_H */

--- a/jemalloc/include/jemalloc/internal/base_externs.h
+++ b/jemalloc/include/jemalloc/internal/base_externs.h
@@ -5,7 +5,8 @@ extern metadata_thp_mode_t opt_metadata_thp;
 extern const char *metadata_thp_mode_names[];
 
 base_t *b0get(void);
-base_t *base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
+base_t *base_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks,
+    bool metadata_use_hooks);
 void base_delete(tsdn_t *tsdn, base_t *base);
 extent_hooks_t *base_extent_hooks_get(base_t *base);
 extent_hooks_t *base_extent_hooks_set(base_t *base,

--- a/jemalloc/include/jemalloc/internal/base_structs.h
+++ b/jemalloc/include/jemalloc/internal/base_structs.h
@@ -27,6 +27,11 @@ struct base_s {
 	 */
 	atomic_p_t	extent_hooks;
 
+	/*
+	 * Use user hooks for metadata when true.
+	 */
+	bool metadata_use_hooks;
+
 	/* Protects base_alloc() and base_stats_get() operations. */
 	malloc_mutex_t	mtx;
 

--- a/jemalloc/include/jemalloc/internal/jemalloc_internal_externs.h
+++ b/jemalloc/include/jemalloc/internal/jemalloc_internal_externs.h
@@ -41,7 +41,7 @@ void *bootstrap_calloc(size_t num, size_t size);
 void bootstrap_free(void *ptr);
 void arena_set(unsigned ind, arena_t *arena);
 unsigned narenas_total_get(void);
-arena_t *arena_init(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks);
+arena_t *arena_init(tsdn_t *tsdn, unsigned ind, const arena_config_t *config);
 arena_tdata_t *arena_tdata_get_hard(tsd_t *tsd, unsigned ind);
 arena_t *arena_choose_hard(tsd_t *tsd, bool internal);
 void arena_migrate(tsd_t *tsd, unsigned oldind, unsigned newind);

--- a/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/jemalloc/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -91,7 +91,7 @@ arena_get(tsdn_t *tsdn, unsigned ind, bool init_if_missing) {
 	if (unlikely(ret == NULL)) {
 		if (init_if_missing) {
 			ret = arena_init(tsdn, ind,
-			    (extent_hooks_t *)&extent_hooks_default);
+			    &arena_config_default);
 		}
 	}
 	return ret;

--- a/jemalloc/src/arena.c
+++ b/jemalloc/src/arena.c
@@ -48,6 +48,12 @@ size_t opt_oversize_threshold = OVERSIZE_THRESHOLD_DEFAULT;
 size_t oversize_threshold = OVERSIZE_THRESHOLD_DEFAULT;
 static unsigned huge_arena_ind;
 
+
+const arena_config_t arena_config_default = {
+	.extent_hooks = (extent_hooks_t *)&extent_hooks_default,
+	.metadata_use_hooks = true,
+};
+
 /******************************************************************************/
 /*
  * Function prototypes for static functions that are referenced prior to
@@ -1939,7 +1945,7 @@ arena_extent_sn_next(arena_t *arena) {
 }
 
 arena_t *
-arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
+arena_new(tsdn_t *tsdn, unsigned ind, const arena_config_t *config) {
 	arena_t *arena;
 	base_t *base;
 	unsigned i;
@@ -1947,7 +1953,12 @@ arena_new(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	if (ind == 0) {
 		base = b0get();
 	} else {
-		base = base_new(tsdn, ind, extent_hooks);
+		extent_hooks_t *extent_hooks = config->extent_hooks ?
+		    config->extent_hooks :
+		    (extent_hooks_t *)&extent_hooks_default;
+
+		base = base_new(tsdn, ind, extent_hooks,
+		    config->metadata_use_hooks);
 		if (base == NULL) {
 			return NULL;
 		}

--- a/jemalloc/src/ctl.c
+++ b/jemalloc/src/ctl.c
@@ -227,6 +227,7 @@ CTL_PROTO(experimental_hooks_remove)
 CTL_PROTO(experimental_utilization_query)
 CTL_PROTO(experimental_utilization_batch_query)
 CTL_PROTO(experimental_arenas_i_pactivep)
+CTL_PROTO(experimental_arenas_create_ext)
 INDEX_PROTO(experimental_arenas_i)
 
 #define MUTEX_STATS_CTL_PROTO_GEN(n)					\
@@ -616,7 +617,8 @@ static const ctl_indexed_node_t experimental_arenas_node[] = {
 static const ctl_named_node_t experimental_node[] = {
 	{NAME("hooks"),		CHILD(named, experimental_hooks)},
 	{NAME("utilization"),	CHILD(named, experimental_utilization)},
-	{NAME("arenas"),	CHILD(indexed, experimental_arenas)}
+	{NAME("arenas"),	CHILD(indexed, experimental_arenas)},
+ 	{NAME("arenas_create_ext"), CTL(experimental_arenas_create_ext)},
 };
 
 static const ctl_named_node_t	root_node[] = {
@@ -1001,7 +1003,7 @@ ctl_arena_refresh(tsdn_t *tsdn, arena_t *arena, ctl_arena_t *ctl_sdarena,
 }
 
 static unsigned
-ctl_arena_init(tsd_t *tsd, extent_hooks_t *extent_hooks) {
+ctl_arena_init(tsd_t *tsd, const arena_config_t *config) {
 	unsigned arena_ind;
 	ctl_arena_t *ctl_arena;
 
@@ -1019,7 +1021,7 @@ ctl_arena_init(tsd_t *tsd, extent_hooks_t *extent_hooks) {
 	}
 
 	/* Initialize new arena. */
-	if (arena_init(tsd_tsdn(tsd), arena_ind, extent_hooks) == NULL) {
+	if (arena_init(tsd_tsdn(tsd), arena_ind, config) == NULL) {
 		return UINT_MAX;
 	}
 
@@ -2392,8 +2394,12 @@ arena_i_extent_hooks_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
 				extent_hooks_t *new_extent_hooks
 				    JEMALLOC_CC_SILENCE_INIT(NULL);
 				WRITE(new_extent_hooks, extent_hooks_t *);
+
+				arena_config_t config = arena_config_default;
+				config.extent_hooks = new_extent_hooks;
+
 				arena = arena_init(tsd_tsdn(tsd), arena_ind,
-				    new_extent_hooks);
+				    &config);
 				if (arena == NULL) {
 					ret = EFAULT;
 					goto label_return;
@@ -2582,19 +2588,41 @@ static int
 arenas_create_ctl(tsd_t *tsd, const size_t *mib, size_t miblen,
     void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
 	int ret;
-	extent_hooks_t *extent_hooks;
 	unsigned arena_ind;
 
 	malloc_mutex_lock(tsd_tsdn(tsd), &ctl_mtx);
 
-	extent_hooks = (extent_hooks_t *)&extent_hooks_default;
-	WRITE(extent_hooks, extent_hooks_t *);
-	if ((arena_ind = ctl_arena_init(tsd, extent_hooks)) == UINT_MAX) {
+	arena_config_t config = arena_config_default;
+	WRITE(config.extent_hooks, extent_hooks_t *);
+	if ((arena_ind = ctl_arena_init(tsd, &config)) == UINT_MAX) {
 		ret = EAGAIN;
 		goto label_return;
 	}
 	READ(arena_ind, unsigned);
 
+	ret = 0;
+label_return:
+	malloc_mutex_unlock(tsd_tsdn(tsd), &ctl_mtx);
+	return ret;
+}
+
+static int
+experimental_arenas_create_ext_ctl(tsd_t *tsd,
+    const size_t *mib, size_t miblen,
+    void *oldp, size_t *oldlenp, void *newp, size_t newlen) {
+	int ret;
+	unsigned arena_ind;
+
+	malloc_mutex_lock(tsd_tsdn(tsd), &ctl_mtx);
+
+	arena_config_t config = arena_config_default;
+	WRITE(config, arena_config_t);
+
+	if ((arena_ind = ctl_arena_init(tsd, &config)) == UINT_MAX) {
+		ret = EAGAIN;
+		goto label_return;
+	}
+	READ(arena_ind, unsigned);
 	ret = 0;
 label_return:
 	malloc_mutex_unlock(tsd_tsdn(tsd), &ctl_mtx);

--- a/jemalloc/src/jemalloc.c
+++ b/jemalloc/src/jemalloc.c
@@ -315,7 +315,7 @@ narenas_total_get(void) {
 
 /* Create a new arena and insert it into the arenas array at index ind. */
 static arena_t *
-arena_init_locked(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
+arena_init_locked(tsdn_t *tsdn, unsigned ind, const arena_config_t *config) {
 	arena_t *arena;
 
 	assert(ind <= narenas_total_get());
@@ -337,7 +337,7 @@ arena_init_locked(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
 	}
 
 	/* Actually initialize the arena. */
-	arena = arena_new(tsdn, ind, extent_hooks);
+	arena = arena_new(tsdn, ind, config);
 
 	return arena;
 }
@@ -361,11 +361,11 @@ arena_new_create_background_thread(tsdn_t *tsdn, unsigned ind) {
 }
 
 arena_t *
-arena_init(tsdn_t *tsdn, unsigned ind, extent_hooks_t *extent_hooks) {
+arena_init(tsdn_t *tsdn, unsigned ind, const arena_config_t *config) {
 	arena_t *arena;
 
 	malloc_mutex_lock(tsdn, &arenas_lock);
-	arena = arena_init_locked(tsdn, ind, extent_hooks);
+	arena = arena_init_locked(tsdn, ind, config);
 	malloc_mutex_unlock(tsdn, &arenas_lock);
 
 	arena_new_create_background_thread(tsdn, ind);
@@ -577,7 +577,7 @@ arena_choose_hard(tsd_t *tsd, bool internal) {
 				choose[j] = first_null;
 				arena = arena_init_locked(tsd_tsdn(tsd),
 				    choose[j],
-				    (extent_hooks_t *)&extent_hooks_default);
+				    &arena_config_default);
 				if (arena == NULL) {
 					malloc_mutex_unlock(tsd_tsdn(tsd),
 					    &arenas_lock);
@@ -1550,7 +1550,7 @@ malloc_init_hard_a0_locked() {
 	 * Initialize one arena here.  The rest are lazily created in
 	 * arena_choose_hard().
 	 */
-	if (arena_init(TSDN_NULL, 0, (extent_hooks_t *)&extent_hooks_default)
+	if (arena_init(TSDN_NULL, 0, &arena_config_default)
 	    == NULL) {
 		return true;
 	}

--- a/jemalloc/test/unit/base.c
+++ b/jemalloc/test/unit/base.c
@@ -31,7 +31,7 @@ TEST_BEGIN(test_base_hooks_default) {
 	size_t allocated0, allocated1, resident, mapped, n_thp;
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
-	base = base_new(tsdn, 0, (extent_hooks_t *)&extent_hooks_default);
+	base = base_new(tsdn, 0, (extent_hooks_t *)&extent_hooks_default, true);
 
 	if (config_stats) {
 		base_stats_get(tsdn, base, &allocated0, &resident, &mapped,
@@ -73,7 +73,7 @@ TEST_BEGIN(test_base_hooks_null) {
 	memcpy(&hooks, &hooks_null, sizeof(extent_hooks_t));
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
-	base = base_new(tsdn, 0, &hooks);
+	base = base_new(tsdn, 0, &hooks, true);
 	assert_ptr_not_null(base, "Unexpected base_new() failure");
 
 	if (config_stats) {
@@ -119,7 +119,7 @@ TEST_BEGIN(test_base_hooks_not_null) {
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	did_alloc = false;
-	base = base_new(tsdn, 0, &hooks);
+	base = base_new(tsdn, 0, &hooks, true);
 	assert_ptr_not_null(base, "Unexpected base_new() failure");
 	assert_true(did_alloc, "Expected alloc");
 

--- a/src/memkind_pmem.c
+++ b/src/memkind_pmem.c
@@ -250,9 +250,10 @@ MEMKIND_EXPORT int memkind_pmem_create(struct memkind *kind,
         goto exit;
     }
     if (memkind_get_hog_memory()) {
-        err = memkind_arena_create_map(kind, &pmem_extent_hooks_hog_memory);
+        err = memkind_arena_create_map(kind, &pmem_extent_hooks_hog_memory,
+                                       false);
     } else {
-        err = memkind_arena_create_map(kind, &pmem_extent_hooks);
+        err = memkind_arena_create_map(kind, &pmem_extent_hooks, false);
     }
     if (err) {
         goto exit;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This patch makes it so that metadata is no longer allocated using the extent hooks in the pmem (fsdax) kind. This helps reduce fragmentation/address space leaks with `HOG_MEMORY` option set.

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/705)
<!-- Reviewable:end -->
