### PR TITLE
Fix building when malloc_usable_size() requires a "const void*" argument

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -356,8 +356,21 @@ if test "x$memkind_sync_fetch" = "x1" ; then
   AC_DEFINE([MEMKIND_ATOMIC_SYNC_SUPPORT], [1], [__sync_* compiler builtins are supported])
 fi
 
-#============================cxx11=============================================
+#===============================malloc_usable_size=============================
+AC_CHECK_HEADERS(malloc.h)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <malloc.h>
+#include <stddef.h>
+]],[[
+size_t malloc_usable_size(const void *ptr);
+]])], [memkind_malloc_usable_size_const="1"], [memkind_malloc_usable_size_const="0"])
+if test "x$memkind_malloc_usable_size_const" = "x1" ; then
+  AC_DEFINE([MEMKIND_MALLOC_USABLE_SIZE_CONST], [const], [malloc_usable_size accepts const ptr])
+else
+  AC_DEFINE([MEMKIND_MALLOC_USABLE_SIZE_CONST], [], [malloc_usable_size doesn't accept const ptr])
+fi
 
+#============================cxx11=============================================
 AX_CXX_COMPILE_STDCXX_11([noext], [optional])
 AM_CONDITIONAL([HAVE_CXX11], [test "x$HAVE_CXX11" = x1])
 

--- a/include/memkind.h
+++ b/include/memkind.h
@@ -9,6 +9,8 @@ extern "C" {
 #include <stdbool.h>
 #include <sys/types.h>
 
+#include "config.h"
+
 /**
  * Header file for the memkind heap manager.
  * More details in memkind(3) man page.
@@ -574,7 +576,8 @@ void *memkind_malloc(memkind_t kind, size_t size);
 /// \param ptr pointer to the allocated memory
 /// \return Number of usable bytes
 ///
-size_t memkind_malloc_usable_size(memkind_t kind, void *ptr);
+size_t memkind_malloc_usable_size(memkind_t kind,
+                                  MEMKIND_MALLOC_USABLE_SIZE_CONST void *ptr);
 
 ///
 /// \brief Allocates memory of the specified kind for an array of num elements

--- a/src/memkind.c
+++ b/src/memkind.c
@@ -830,8 +830,9 @@ MEMKIND_EXPORT ssize_t memkind_get_capacity(struct memkind *kind)
     return capacity;
 }
 
+// clang-format off
 MEMKIND_EXPORT size_t memkind_malloc_usable_size(struct memkind *kind,
-                                                 void *ptr)
+                                                 MEMKIND_MALLOC_USABLE_SIZE_CONST void *ptr)
 {
     if (!kind) {
         return m_usable_size(ptr);
@@ -839,6 +840,7 @@ MEMKIND_EXPORT size_t memkind_malloc_usable_size(struct memkind *kind,
         return kind->ops->malloc_usable_size(kind, ptr);
     }
 }
+// clang-format on
 
 MEMKIND_EXPORT void *memkind_malloc(struct memkind *kind, size_t size)
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/713)
<!-- Reviewable:end -->
