### PR TITLE
Match the type of PMEM_DIR.

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3,7 +3,7 @@
 
 #include "common.h"
 
-char *PMEM_DIR = const_cast<char *>("/tmp/");
+const char *PMEM_DIR = const_cast<char *>("/tmp/");
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
```
test/memkind_detect_kind_tests.cpp:7:20: error: 'PMEM_DIR' violates the C++ One Definition Rule [-Werror=odr]
    7 | extern const char *PMEM_DIR;
      |                    ^
test/main.cpp:6:7: note: type 'char' should match type 'const char'
    6 | char *PMEM_DIR = const_cast<char *>("/tmp/");
      |       ^
test/main.cpp:6:7: note: 'PMEM_DIR' was previously declared here
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/730)
<!-- Reviewable:end -->
