### PR TITLE
Set up apt-get proxy in Ubuntu Dockerfile

### DIFF
--- a/utils/docker/Dockerfile.ubuntu-20.04
+++ b/utils/docker/Dockerfile.ubuntu-20.04
@@ -6,6 +6,9 @@ FROM ubuntu:20.04
 
 LABEL maintainer="michal.biesek@intel.com"
 
+# Set apt-get proxy
+RUN echo "Acquire::http::proxy \"$HTTP_PROXY\";\nAcquire::https::proxy \"$HTTPS_PROXY\";" > /etc/apt/apt.conf
+
 # Update the Apt cache and install basic tools
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     asciidoctor \


### PR DESCRIPTION
Without setting up proxy for apt-get explicitly, apt-get failed to
connect to network when cached Dockerfile was used and Dockerfile
contents changed.
This failure of apt-get was also seen when using created container with
an interactive console.
This commit fixes both issues.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/737)
<!-- Reviewable:end -->
