### PR TITLE
PEBS tweaks

### DIFF
--- a/src/pebs.c
+++ b/src/pebs.c
@@ -38,6 +38,7 @@ void pebs_monitor()
     for (size_t cpu_idx = 0u; cpu_idx < CPU_LOGICAL_CORES_NUMBER; ++cpu_idx) {
         perf_event_mmap_page_t *pebs_metadata =
             (perf_event_mmap_page_t *)pebs_mmap[cpu_idx];
+        assert(pebs_metadata);
 
         __u64 timestamp = 0;
         __u64 addr = 0;
@@ -115,9 +116,9 @@ void pebs_create()
     // check if we have access to perf events
     int pf = 0;
     FILE *f = fopen("/proc/sys/kernel/perf_event_paranoid", "r");
-    if (fscanf(f, "%d", &pf) == 0 || pf > 0) {
+    if (fscanf(f, "%d", &pf) == 0 || pf > 3) {
         log_fatal("PEBS: /proc/sys/kernel/perf_event_paranoid is set to %d "
-                  "while it should be set to 0!",
+                  "while it should be set to 3 or less!",
                   pf);
         exit(-1);
     }

--- a/test/memkind_memtier_data_movement_test.cpp
+++ b/test/memkind_memtier_data_movement_test.cpp
@@ -379,7 +379,7 @@ TEST(DataMovementBgThreadTest, test_bg_thread_lifecycle)
 TEST(PEBS, Basic)
 {
     // do some copying - L3 misses are expected here
-    const int size = 1024 * 1024 * 1024;
+    const int size = 1024 * 1024;
     volatile int total_sum = 0;
     volatile int *tab = (int *)malloc(size * sizeof(int));
     for (int i = 0; i < size; i++) {


### PR DESCRIPTION
* shorten PEBS.Basic test
* allow perf_event_paranoid to be <= 3
* fix crash when PEBS is disabled

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/744)
<!-- Reviewable:end -->
