### PR TITLE
Dynamically allocate pebs metadata buffers, based on the number of cpus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -523,7 +523,7 @@ noinst_LTLIBRARIES =
 TESTS =
 
 req_flags = -fvisibility=hidden -Wall -Werror -D_GNU_SOURCE -DJE_PREFIX=@memkind_prefix@ \
--DMEMTIER_ALLOC_PREFIX=@memtier_prefix@ -DCPU_LOGICAL_CORES_NUMBER=`nproc --all`
+-DMEMTIER_ALLOC_PREFIX=@memtier_prefix@
 
 AM_CFLAGS = $(req_flags) -std=gnu11
 AM_CXXFLAGS = $(req_flags)

--- a/include/memkind/internal/pebs.h
+++ b/include/memkind/internal/pebs.h
@@ -33,16 +33,11 @@ typedef struct perf_event_header perf_event_header_t;
 
 typedef void (*touch_cb)(uintptr_t address, uint64_t timestamp);
 
-// to avoid VSCode editor errors
-// TODO remove after POC (generate this define with ./configure)
-#ifndef CPU_LOGICAL_CORES_NUMBER
-#define CPU_LOGICAL_CORES_NUMBER 1
-#endif
-
 typedef struct PebsMetadata {
-    int pebs_fd[CPU_LOGICAL_CORES_NUMBER];
-    char *pebs_mmap[CPU_LOGICAL_CORES_NUMBER];
-    __u64 last_head[CPU_LOGICAL_CORES_NUMBER];
+    int *pebs_fd;
+    void **pebs_mmap;
+    __u64 *last_head;
+    size_t nof_cpus;
     touch_cb cb;
 } PebsMetadata;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/773)
<!-- Reviewable:end -->
