### PR TITLE
Lower DRAM overhead by using global const exponential coeffs

### DIFF
--- a/include/memkind/internal/ranking_internals.hpp
+++ b/include/memkind/internal/ranking_internals.hpp
@@ -63,9 +63,20 @@ public:
     double Get();
 };
 
+class SlimHotnessCoeff
+{
+    double value_;
+
+public:
+    SlimHotnessCoeff(double init_hotness);
+    void Update(double hotness_to_add, double timediff,
+                double exponential_coeff, double compensation_coeff);
+    double Get();
+};
+
 class Hotness
 {
-    HotnessCoeff coeffs[EXPONENTIAL_COEFFS_NUMBER];
+    SlimHotnessCoeff coeffs[EXPONENTIAL_COEFFS_NUMBER];
     uint64_t previousTimestamp;
 
 public:

--- a/test/memkind_memtier_data_movement_test.cpp
+++ b/test/memkind_memtier_data_movement_test.cpp
@@ -828,6 +828,15 @@ TEST(HotnessCoeffTest, Basic)
     c0.Update(5.0, 1.0);
     ASSERT_EQ(c0.Get(), 2.5);
 
+    SlimHotnessCoeff sc0(0);
+    ASSERT_EQ(sc0.Get(), 0.0);
+    sc0.Update(3.0, 0.0, 0, 0.5);
+    ASSERT_EQ(sc0.Get(), 1.5);
+    sc0.Update(5.0, 0.0, 0, 0.5);
+    ASSERT_EQ(sc0.Get(), 4.0);
+    sc0.Update(5.0, 1.0, 0, 0.5);
+    ASSERT_EQ(sc0.Get(), 2.5);
+
     HotnessCoeff c1(10, 0.3, 2.0);
     ASSERT_EQ(c1.Get(), 10.0);
     c1.Update(0.0, 0.0);
@@ -841,6 +850,19 @@ TEST(HotnessCoeffTest, Basic)
     c1.Update(3.0, 2.0);
     ASSERT_EQ(c1.Get(), 2.7 + 6.0);
 
+    SlimHotnessCoeff sc1(10);
+    ASSERT_EQ(sc1.Get(), 10.0);
+    sc1.Update(0.0, 0.0, 0.3, 2.0);
+    ASSERT_EQ(sc1.Get(), 10.0);
+    sc1.Update(45.0, 0.0, 0.3, 2.0);
+    ASSERT_EQ(sc1.Get(), 100.0);
+    sc1.Update(0.0, 0.0, 0.3, 2.0);
+    ASSERT_EQ(sc1.Get(), 100.0);
+    sc1.Update(0.0, 1.0, 0.3, 2.0);
+    ASSERT_EQ(sc1.Get(), 30.0);
+    sc1.Update(3.0, 2.0, 0.3, 2.0);
+    ASSERT_EQ(sc1.Get(), 2.7 + 6.0);
+
     // check double overflow
     c1.Update(std::numeric_limits<double>::max() / 2, 0.5);
     c1.Update(std::numeric_limits<double>::max() / 2, 0.1);
@@ -849,10 +871,21 @@ TEST(HotnessCoeffTest, Basic)
     c1.Update(std::numeric_limits<double>::max() / 2, 0.02);
     ASSERT_EQ(c1.Get(), std::numeric_limits<double>::max());
 
+    sc1.Update(std::numeric_limits<double>::max() / 2, 0.5, 0.3, 2.0);
+    sc1.Update(std::numeric_limits<double>::max() / 2, 0.1, 0.3, 2.0);
+    sc1.Update(std::numeric_limits<double>::max() / 2, 0.2, 0.3, 2.0);
+    sc1.Update(std::numeric_limits<double>::max() / 2, 0.01, 0.3, 2.0);
+    sc1.Update(std::numeric_limits<double>::max() / 2, 0.02, 0.3, 2.0);
+    ASSERT_EQ(sc1.Get(), std::numeric_limits<double>::max());
+
     // check if value still decreases with time
     c1.Update(0, 2);
     ASSERT_LT(c1.Get(), std::numeric_limits<double>::max());
     ASSERT_GT(c1.Get(), 0);
+
+    sc1.Update(0, 2, 0.3, 2.0);
+    ASSERT_LT(sc1.Get(), std::numeric_limits<double>::max());
+    ASSERT_GT(sc1.Get(), 0);
 }
 
 TEST(HotnessTest, Basic)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [x] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->
