### PR TITLE
Fix failing DAX_KMEM_PREFERRED test

### DIFF
--- a/test/memkind_dax_kmem_test.cpp
+++ b/test/memkind_dax_kmem_test.cpp
@@ -384,7 +384,6 @@ TEST_F(MemkindDaxKmemFunctionalTestsPreferred,
     std::set<void *> allocations;
     size_t numa_size;
     int numa_id = -1;
-    const int n_swap_alloc = 20;
 
     void *ptr = memkind_malloc(MEMKIND_DAX_KMEM_PREFERRED, alloc_size);
     ASSERT_NE(nullptr, ptr);
@@ -399,9 +398,20 @@ TEST_F(MemkindDaxKmemFunctionalTestsPreferred,
     auto closest_numa_ids =
         tp.get_closest_numa_nodes(process_node, dax_kmem_nodes);
 
-    numa_size = numa_node_size64(numa_id, nullptr);
+    // Get free size of the closest DAX_KMEM NUMA node
+    long long numa_free_size;
+    numa_size = numa_node_size64(numa_id, &numa_free_size);
+    ASSERT_GT(numa_size, 0U);
 
-    while (0.99 * numa_size > alloc_size * allocations.size()) {
+    // Due to fragmentation there is no guarantee that the 100% of free size in
+    // the closest DAX_KMEM NUMA node can be allocated.
+    size_t free_size_limit = 0.99 * (size_t)numa_free_size;
+    const int allocs_no = free_size_limit / alloc_size;
+    const int extra_allocs_no =
+        ((size_t)numa_free_size - free_size_limit) / alloc_size + 1;
+
+    // Allocate up to 99% of free space on the closest DAX_KMEM NUMA node
+    for (int i = 0; i < allocs_no; ++i) {
         ptr = memkind_malloc(MEMKIND_DAX_KMEM_PREFERRED, alloc_size);
         ASSERT_NE(nullptr, ptr);
         memset(ptr, 'a', alloc_size);
@@ -411,13 +421,22 @@ TEST_F(MemkindDaxKmemFunctionalTestsPreferred,
         ASSERT_TRUE(closest_numa_ids.find(numa_id) != closest_numa_ids.end());
     }
 
-    for (int i = 0; i < n_swap_alloc; ++i) {
+    // Allocate more than the rest of the free space allow - the total
+    // allocations made are the sum of allocs_no and extra_allocs_no -
+    // allocations should spill to other NUMA node
+    for (int i = 0; i < extra_allocs_no; ++i) {
         ptr = memkind_malloc(MEMKIND_DAX_KMEM_PREFERRED, alloc_size);
         ASSERT_NE(nullptr, ptr);
         memset(ptr, 'a', alloc_size);
         allocations.insert(ptr);
     }
 
+    // The last allocation should be done to other NUMA node than the closest
+    // DAX_KMEM NUMA node
+    get_mempolicy(&numa_id, nullptr, 0, ptr, MPOL_F_NODE | MPOL_F_ADDR);
+    ASSERT_TRUE(closest_numa_ids.find(numa_id) == closest_numa_ids.end());
+
+    // None of the allocations should be made to the swap space
     ASSERT_EQ(stat.get_used_swap_space_size_bytes(), 0U);
 
     for (auto const &ptr : allocations) {


### PR DESCRIPTION
Due to fragmentation there is no guarantee that the 100% of free size in
the closest DAX_KMEM NUMA node can be allocated. The test modified to
rely on the available free space rather than the total memory capacity
of given NUMA node.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/783)
<!-- Reviewable:end -->
