### PR TITLE
handle fork()

### DIFF
--- a/include/memkind/internal/pebs.h
+++ b/include/memkind/internal/pebs.h
@@ -38,6 +38,8 @@ struct MTTAllocator;
 
 void pebs_create(struct MTTAllocator *mtt_allocator, PebsMetadata *pebs,
                  touch_cb cb);
+void pebs_enable(struct MTTAllocator *mtt_allocator, PebsMetadata *pebs);
+void pebs_disable(struct MTTAllocator *mtt_allocator, PebsMetadata *pebs);
 void pebs_destroy(struct MTTAllocator *mtt_allocator, PebsMetadata *pebs);
 void pebs_monitor(PebsMetadata *pebs);
 


### PR DESCRIPTION
Because fork() kills all other threads, even if they hold a lock, we need to explicitly stop our background thread then restart it afterwards.  We need to also re-register PEBS events; it might be possible to avoid deregistering the parent, but let's play it safe.  Worst case, some concurrent accesses will be lost, but we don't try to catch everything anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/784)
<!-- Reviewable:end -->
