### PR TITLE
Fix Klocwork issues

### DIFF
--- a/src/memkind_fixed.c
+++ b/src/memkind_fixed.c
@@ -185,7 +185,8 @@ MEMKIND_EXPORT int memkind_fixed_create(struct memkind *kind,
 
     if (pthread_mutex_init(&priv->lock, NULL) != 0) {
         err = MEMKIND_ERROR_RUNTIME;
-        goto exit;
+        jemk_free(priv);
+        return err;
     }
 
     err = memkind_default_create(kind, ops, name);
@@ -204,7 +205,7 @@ MEMKIND_EXPORT int memkind_fixed_create(struct memkind *kind,
 exit:
     /* err is set, please don't overwrite it with result of
      * pthread_mutex_destroy */
-    pthread_mutex_destroy(&priv->lock);
+    (void)pthread_mutex_destroy(&priv->lock);
     jemk_free(priv);
     return err;
 }
@@ -215,11 +216,11 @@ MEMKIND_EXPORT int memkind_fixed_destroy(struct memkind *kind)
 
     memkind_arena_destroy(kind);
     memtier_reset_size(kind->partition);
-    pthread_mutex_destroy(&priv->lock);
+    int ret = pthread_mutex_destroy(&priv->lock);
 
     jemk_free(priv);
 
-    return 0;
+    return ret;
 }
 
 MEMKIND_EXPORT void *memkind_fixed_mmap(struct memkind *kind, void *addr,


### PR DESCRIPTION
* handle pthread_mutex_* errors in fixed kind
* do not use execvpe()

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/791)
<!-- Reviewable:end -->
