### PR TITLE
fix a bad ratio calculation in the wrapper

### DIFF
--- a/utils/memtier/memtier.c
+++ b/utils/memtier/memtier.c
@@ -67,7 +67,11 @@ static size_t human_friendly_ratio(size_t x, size_t y)
             continue;
         if (a * y * ACCURACY < x * b) // too little?
             continue;
-        return x / a;
+        // The ratios are 𝑎𝑙𝑚𝑜𝑠𝑡 equal, we need to round up here.
+        if (x / a < y / b)
+            return x / a;
+        else
+            return y / b;
     }
 }
 

--- a/utils/memtier/tests
+++ b/utils/memtier/tests
@@ -26,6 +26,7 @@ calc_ratio 512G 4T 1:8
 calc_ratio 1000017 3000000 1:3
 calc_ratio 20G 50G 2:5
 calc_ratio 740 500 3:2
+calc_ratio 259872501760 128835989504 2:1
 
 bad_r()
 {


### PR DESCRIPTION
The bad case I found was 259872501760:128835989504 which ended up as 2:0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/794)
<!-- Reviewable:end -->
