### PR TITLE
Fix failure when passing MTT_LIMITS env var

### DIFF
--- a/tiering/ctl.c
+++ b/tiering/ctl.c
@@ -609,6 +609,11 @@ struct memtier_memory *ctl_create_tier_memory_from_env(char *env_var_string)
 
     char *limits_env = utils_get_env("MEMKIND_MTT_LIMITS");
     if (limits_env) {
+        if (policy != MEMTIER_POLICY_DATA_MOVEMENT) {
+            log_err(
+                "MEMKIND_MTT_LIMITS env var should be set only when DATA_MOVEMENT policy is used!");
+            goto destroy_builder;
+        }
         char limits_env_local[MAX_ENV_STRING] = {0};
         strncpy(limits_env_local, limits_env, MAX_ENV_STRING - 1);
 


### PR DESCRIPTION
in cases when the MEMKIND_MTT_LIMITS env var is set but policies other
than DATA_MOVEMENT are set in the MEMKIND_MEM_TIERS env var.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/819)
<!-- Reviewable:end -->
