### PR TITLE
Return correct usable size

### DIFF
--- a/src/slab_allocator.c
+++ b/src/slab_allocator.c
@@ -221,5 +221,5 @@ MEMKIND_EXPORT size_t slab_allocator_usable_size(void *addr)
 {
     freelist_node_meta_t *meta = slab_alloc_addr_to_node_meta_(addr);
     SlabAllocator *alloc = meta->allocator;
-    return alloc->elementSize;
+    return alloc->elementSize - sizeof(freelist_node_meta_t);
 }


### PR DESCRIPTION
The returned size of slab_allocator_usable_size() included 16 bytes
which are reserved for slab metadata. This commit fixes this function
to return the size which is actually available for the given allocation.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/820)
<!-- Reviewable:end -->
