### PR TITLE
Run DAX_KMEM tests regardless of the CPU model

### DIFF
--- a/test/TestPrereq.hpp
+++ b/test/TestPrereq.hpp
@@ -62,8 +62,6 @@ private:
 #define CPUID_FAMILY_SHIFT    (8)
 #define CPU_MODEL_KNL         (0x57)
 #define CPU_MODEL_KNM         (0x85)
-#define CPU_MODEL_CLX         (0x55)
-#define CPU_MODEL_PMEM        (0x6A)
 #define CPU_FAMILY_INTEL      (0x06)
 
     typedef struct {
@@ -109,7 +107,7 @@ private:
     {
         if (getenv(env_var) != NULL)
             return true;
-        else if (!check_cpu(mem_var))
+        else if (mem_var == HBM && !is_KN_family_supported())
             return false;
         else if (find_type(mem_var))
             return true;
@@ -144,22 +142,6 @@ public:
         hwloc_topology_destroy(topology);
     }
 #endif
-
-    bool check_cpu(memory_var variant) const
-    {
-        switch (variant) {
-            case HBM:
-                return is_KN_family_supported();
-            case PMEM:
-            {
-                cpu_model_data_t cpu = get_cpu_model_data();
-                return cpu.family == CPU_FAMILY_INTEL &&
-                    (cpu.model == CPU_MODEL_CLX || cpu.model == CPU_MODEL_PMEM);
-            }
-            default:
-                return false;
-        }
-    }
 
     std::unordered_set<int>
     get_closest_numa_nodes(int first_node, std::unordered_set<int> nodes) const


### PR DESCRIPTION
For running DAX_KMEM tests having DAX_KMEM NUMA nodes set up should be
enough. No need for restricting these tests to certain CPU models.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/838)
<!-- Reviewable:end -->
