### PR TITLE
Pass PMEM directory as argument to test script

### DIFF
--- a/test/run_alloc_benchmark.sh
+++ b/test/run_alloc_benchmark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-2-Clause
-# Copyright (C) 2014 - 2020 Intel Corporation.
+# Copyright (C) 2014 - 2022 Intel Corporation.
 
 # Allocator
 ALLOCATOR="glibc tbb hbw pmem"
@@ -25,8 +25,12 @@ average free time [ms], first allocation time [ms], first free time [ms]" >> all
         # For each amount of memory
         for mem in ${MEMORY[*]}
         do
-            echo "OMP_NUM_THREADS=$nthr ./alloc_benchmark_$alloc $ITERS $mem >> alloctest_$alloc.txt"
-            OMP_NUM_THREADS=$nthr ./alloc_benchmark_$alloc $ITERS $mem >> alloctest_$alloc.txt
+            if [ $alloc == "pmem" ]; then
+                DIR=$1
+            fi
+
+            echo "OMP_NUM_THREADS=$nthr ./alloc_benchmark_$alloc $ITERS $mem $DIR >> alloctest_$alloc.txt"
+            OMP_NUM_THREADS=$nthr ./alloc_benchmark_$alloc $ITERS $mem $DIR >> alloctest_$alloc.txt
             ret=$?
             if [ $ret -ne 0 ]; then
                 echo "Error: alloc_benchmark_$alloc returned $ret"


### PR DESCRIPTION
Pass PMEM directory as argument to test script

### Description
By default the alloc_benchmark defaults to `/tmp` if the directory is not passed to the allocator file.
The change uses the first argument as the directory for the pmem tests, the other tests should not be affected

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [x] Bugfix (non-breaking change which fixes issue linked in Description above)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/840)
<!-- Reviewable:end -->
