### PR TITLE
Pass any non-zero return on 'make man-local' error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -664,11 +664,11 @@ AM_CXXFLAGS = $(req_flags)
 clean-local: clean-jemalloc_deps
 
 man-local:
-	for doc_name in $(dist_doc_DOCS) ; do \
+	@for doc_name in $(dist_doc_DOCS) ; do \
 		utils/md2man/md2man.sh \
 			doc/$$doc_name.md \
 			utils/md2man/default.man \
-			man/$$doc_name ; \
+			man/$$doc_name || exit $$? ; \
 	done
 
 clean-jemalloc_deps:


### PR DESCRIPTION
Previously this script could fail (e.g., because of missing doc file) and did not return any error, silently skipping over an issue.

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [x] Code compiles without errors
- [x] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/864)
<!-- Reviewable:end -->
