### PR TITLE
Add JEMALLOC oversize_threshold configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -707,7 +707,7 @@ static_lib: jemalloc_deps libmemkind.la
 
 JEMALLOC_CONFIG = --enable-autogen @min_lg_align_opt@ --without-export --with-version=5.3.0-0-g54eaed1d8b56b1aa528be3bdd1877e59c56fa90c \
 			@jemalloc_build_type_flags@  @memkind_initial_exec_tls@ --with-jemalloc-prefix=@memkind_prefix@ \
-			--with-malloc-conf="narenas:@auto_arenas@,lg_tcache_max:@tcache_max_size_class@" \
+			--with-malloc-conf="narenas:@auto_arenas@,lg_tcache_max:@tcache_max_size_class@,oversize_threshold:@oversize_threshold@" \
 			#end
 
 jemalloc_deps:

--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,18 @@ fi
 
 AC_DEFINE_UNQUOTED([ARENA_LIMIT_PER_KIND], $arena_limit, [Upper bound for number of arenas per kind])
 
+#============================oversize_threshold================================
+oversize_threshold=8388608; # Defaults to 8MB as per jemalloc settings
+AC_ARG_VAR(OVERSIZE_THRESHOLD,
+	   [Requests in bytes greater than this value are allocated from a dedicated arena seperated from the narenas]
+)
+
+if test "$OVERSIZE_THRESHOLD" != "" ; then
+  oversize_threshold=$OVERSIZE_THRESHOLD;
+fi
+
+AC_SUBST(oversize_threshold)
+
 #============================memkind_prefix=======================================
 memkind_prefix=jemk_;
 AC_ARG_VAR(MEMKIND_PREFIX,


### PR DESCRIPTION
Add JEMALLOC oversize_threshold configuration

### Description
This allows you to configure the oversize_threshold size when building memkind.
If there is no value configure it defaults to the original value of 8MB.
### Usage
To configure the threshold size you need to set the environment variable `OVERSIZE_THRESHOLD` to the value to want to use.

### Types of changes
<!--- Put an `x` in the box(es) that apply -->

- [ ] Bugfix (non-breaking change which fixes issue linked in Description above)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [ ] Other

### Checklist
<!--- Put an `x` in the box(es) that apply -->

- [ ] Code compiles without errors
- [ ] All tests pass locally with my changes (see TESTING section in CONTRIBUTING file)
- [ ] Created tests which will fail without the change (if possible)
- [ ] Extended the README/documentation (if necessary)
- [ ] All newly added files have proprietary license (if necessary)
- [ ] All newly added files are referenced in MANIFEST files (if necessary)

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you -->
<!--- choose the solution you did and what alternatives you considered, etc... -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/memkind/memkind/885)
<!-- Reviewable:end -->
