### PR TITLE
fix build failure with gcc-13

### DIFF
--- a/test/performance/operations.hpp
+++ b/test/performance/operations.hpp
@@ -8,6 +8,7 @@
 #include "jemalloc/jemalloc.h"
 #include <cassert>
 #include <malloc.h>
+#include <string>
 
 // Malloc, jemalloc, memkind jemalloc and memkind memory operations definitions
 namespace performance_tests


### PR DESCRIPTION
As [reported in Debian](https://bugs.debian.org/1037773), there's a build failure with gcc-13:

```
In file included from test/performance/framework.hpp:13,
                 from test/performance/perf_tests.hpp:6,
                 from test/performance/perf_tests.cpp:4:
test/performance/operations.hpp:109:5: error: return type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} is incomplete
  109 |     {
      |     ^
test/performance/framework.hpp:245:48: error: could not convert ‘""’ from ‘const char [1]’ to ‘const std::string&’ {aka ‘const std::__cxx11::basic_string<char>&’}
  245 |                       const string &fileName = "");
      |                                                ^~
      |                                                |
      |                                                const char [1]
```

`#include <string>` makes the type complete.